### PR TITLE
Improve security config, exception handler, and dependency scoping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ dependencies {
 
 	// Runtime-only (실행 시에만 필요)
 	runtimeOnly 'com.h2database:h2'
-	// H2 콘솔 (Spring Boot 4 — 별도 모듈로 분리됨)
-	implementation 'org.springframework.boot:spring-boot-h2console'
+	// H2 콘솔 (Spring Boot 4 — 별도 모듈로 분리됨, 개발 전용)
+	developmentOnly 'org.springframework.boot:spring-boot-h2console'
 
 	// Annotation processors
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/smartclinic/hms/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/smartclinic/hms/common/exception/GlobalExceptionHandler.java
@@ -29,7 +29,8 @@ import lombok.extern.slf4j.Slf4j;
  *   2. ConstraintViolationException    — @Validated (Path/Query 파라미터 검증 실패)
  *   3. CustomException                 — 도메인 비즈니스 예외
  *   4. EntityNotFoundException         — JPA 리소스 없음
- *   5. Exception                       — 예측 불가 예외 (폴백)
+ *   5. NoResourceFoundException       — 정적 리소스/라우트 없음
+ *   6. Exception                       — 예측 불가 예외 (폴백)
  *
  * ■ 응답 포맷
  *   { "success": false, "errorCode": "...", "message": "...",
@@ -170,10 +171,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleNoResourceFound(
             NoResourceFoundException ex, HttpServletRequest req) {
 
-        log.warn("[GlobalExceptionHandler] 리소스 없음: path={}", req.getRequestURI());
+        log.debug("[GlobalExceptionHandler] 리소스 없음: path={}", req.getRequestURI());
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.of("RESOURCE_NOT_FOUND", ex.getMessage(), req));
+                .body(ErrorResponse.of("ROUTE_NOT_FOUND", ex.getMessage(), req));
     }
 
     // ════════════════════════════════════════════════════════════════════════

--- a/src/main/java/com/smartclinic/hms/config/SecurityConfig.java
+++ b/src/main/java/com/smartclinic/hms/config/SecurityConfig.java
@@ -160,13 +160,6 @@ public class SecurityConfig {
                 .accessDeniedPage("/error/403")
             )
 
-            // ── 보안 헤더 ─────────────────────────────────────────────────
-            // H2 콘솔이 iframe을 사용하므로 sameOrigin 허용 (개발용).
-            // 운영 환경에서 H2 콘솔을 비활성화하면 기본값(DENY)으로 복원 권장.
-            .headers(headers -> headers
-                .frameOptions(frame -> frame.sameOrigin())
-            )
-
             .build();
     }
 


### PR DESCRIPTION
- Change spring-boot-h2console dependency from implementation to developmentOnly
- Remove redundant frameOptions(sameOrigin) from main filter chain (already handled by H2-dedicated chain)
- Downgrade NoResourceFoundException log level from warn to debug to reduce noise
- Use distinct error code ROUTE_NOT_FOUND for NoResourceFoundException (vs RESOURCE_NOT_FOUND for EntityNotFoundException)
- Update class Javadoc to reflect the 6th exception handler