### PR TITLE
fix: API 엔드포인트 보안 강화 — 11개 취약점 수정

### DIFF
--- a/src/main/java/com/smartclinic/hms/_sample/SampleReservationService.java
+++ b/src/main/java/com/smartclinic/hms/_sample/SampleReservationService.java
@@ -120,6 +120,23 @@ public class SampleReservationService {
     public void receive(Long reservationId) {
         SampleReservation reservation = findById(reservationId);
 
+        /*
+         * ── [보안] IDOR 방지 — 객체 수준 권한 검증 (실제 구현 시 필수) ──
+         * ID만으로 리소스에 접근하면 다른 사용자의 데이터를 조작할 수 있음.
+         * SecurityContextHolder에서 현재 로그인 사용자를 확인하여 소유권/권한 검증 필요.
+         *
+         * 예시:
+         * Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+         * String username = auth.getName();
+         * Staff currentStaff = staffRepository.findByUsername(username)
+         *         .orElseThrow(() -> CustomException.unauthorized("인증 정보를 찾을 수 없습니다."));
+         *
+         * // 접수 직원은 자기 부서 예약만 접수 가능하도록 제한
+         * if (!currentStaff.getDepartment().getId().equals(reservation.getDepartmentId())) {
+         *     throw CustomException.forbidden("해당 예약에 대한 접수 권한이 없습니다.");
+         * }
+         */
+
         // 도메인 메서드가 상태 검증 포함 — 잘못된 상태 시 IllegalStateException
         try {
             reservation.receive();
@@ -166,6 +183,19 @@ public class SampleReservationService {
     @Transactional
     public void cancel(Long reservationId) {
         SampleReservation reservation = findById(reservationId);
+
+        /*
+         * ── [보안] IDOR 방지 — 객체 수준 권한 검증 (실제 구현 시 필수) ──
+         * 관리자 전용 취소의 경우에도 로그인 사용자의 ROLE 검증 권장.
+         *
+         * 예시:
+         * Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+         * boolean isAdmin = auth.getAuthorities().stream()
+         *         .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+         * if (!isAdmin) {
+         *     throw CustomException.forbidden("예약 취소 권한이 없습니다.");
+         * }
+         */
 
         try {
             reservation.cancel();

--- a/src/main/java/com/smartclinic/hms/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/smartclinic/hms/auth/CustomUserDetailsService.java
@@ -1,0 +1,37 @@
+package com.smartclinic.hms.auth;
+
+import com.smartclinic.hms.domain.Staff;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * DB 기반 UserDetailsService — Staff 테이블에서 인증 정보 조회
+ *
+ * InMemoryUserDetailsManager 대체.
+ * Staff.role (ADMIN, DOCTOR, NURSE, STAFF) → ROLE_ prefix 자동 변환.
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final StaffRepository staffRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Staff staff = staffRepository.findByUsernameAndActiveTrue(username)
+                .orElseThrow(() -> new UsernameNotFoundException("아이디 또는 비밀번호가 올바르지 않습니다."));
+
+        return new User(
+                staff.getUsername(),
+                staff.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_" + staff.getRole().name()))
+        );
+    }
+}

--- a/src/main/java/com/smartclinic/hms/auth/StaffRepository.java
+++ b/src/main/java/com/smartclinic/hms/auth/StaffRepository.java
@@ -1,0 +1,14 @@
+package com.smartclinic.hms.auth;
+
+import com.smartclinic.hms.domain.Staff;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Staff 엔티티 조회 Repository — Spring Security 인증 연동용
+ */
+public interface StaffRepository extends JpaRepository<Staff, Long> {
+
+    Optional<Staff> findByUsernameAndActiveTrue(String username);
+}

--- a/src/main/java/com/smartclinic/hms/config/RateLimitFilter.java
+++ b/src/main/java/com/smartclinic/hms/config/RateLimitFilter.java
@@ -1,0 +1,123 @@
+package com.smartclinic.hms.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * IP 기반 Rate Limiting 필터 — 토큰 버킷 방식
+ *
+ * 엔드포인트별 차등 제한:
+ *   POST /login      : 10회/분 (브루트포스 방지)
+ *   /llm/symptom/**  : 20회/분 (API 비용 제어)
+ *   기타             : 100회/분
+ *
+ * 초과 시 429 Too Many Requests + JSON 에러 응답 반환.
+ */
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private static final int LOGIN_LIMIT = 10;
+    private static final int LLM_SYMPTOM_LIMIT = 20;
+    private static final int DEFAULT_LIMIT = 100;
+    private static final long WINDOW_MS = 60_000L;
+
+    private final ConcurrentHashMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String clientIp = resolveClientIp(request);
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        int limit = resolveLimit(path, method);
+        String bucketKey = clientIp + ":" + resolveBucketCategory(path, method);
+
+        Bucket bucket = buckets.compute(bucketKey, (key, existing) -> {
+            long now = System.currentTimeMillis();
+            if (existing == null || now - existing.windowStart > WINDOW_MS) {
+                return new Bucket(now, 1);
+            }
+            existing.count++;
+            return existing;
+        });
+
+        if (bucket.count > limit) {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            String json = "{\"success\":false,"
+                    + "\"errorCode\":\"RATE_LIMIT_EXCEEDED\","
+                    + "\"message\":\"요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.\","
+                    + "\"timestamp\":\"" + Instant.now() + "\","
+                    + "\"path\":\"" + path.replace("\"", "\\\"") + "\"}";
+
+            response.getWriter().write(json);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private int resolveLimit(String path, String method) {
+        if ("POST".equalsIgnoreCase(method) && "/login".equals(path)) {
+            return LOGIN_LIMIT;
+        }
+        if (path.startsWith("/llm/symptom")) {
+            return LLM_SYMPTOM_LIMIT;
+        }
+        return DEFAULT_LIMIT;
+    }
+
+    private String resolveBucketCategory(String path, String method) {
+        if ("POST".equalsIgnoreCase(method) && "/login".equals(path)) {
+            return "login";
+        }
+        if (path.startsWith("/llm/symptom")) {
+            return "llm-symptom";
+        }
+        return "default";
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    /** 정적 리소스는 Rate Limit 제외 */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/css/") ||
+               path.startsWith("/js/") ||
+               path.startsWith("/images/") ||
+               path.equals("/favicon.ico") ||
+               path.startsWith("/h2-console");
+    }
+
+    private static class Bucket {
+        long windowStart;
+        int count;
+
+        Bucket(long windowStart, int count) {
+            this.windowStart = windowStart;
+            this.count = count;
+        }
+    }
+}

--- a/src/main/java/com/smartclinic/hms/config/SecurityConfig.java
+++ b/src/main/java/com/smartclinic/hms/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.smartclinic.hms.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -9,17 +10,20 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * ════════════════════════════════════════════════════════════════════════════
@@ -27,6 +31,7 @@ import java.io.IOException;
  * ════════════════════════════════════════════════════════════════════════════
  *
  * ■ 인증 방식: 세션 기반 (Spring Security 기본 세션 — JWT 미사용)
+ * ■ UserDetailsService: CustomUserDetailsService (Staff DB 조회)
  * ■ 역할: ROLE_ADMIN, ROLE_DOCTOR, ROLE_NURSE, ROLE_STAFF
  *
  * ■ URL 접근 권한 (API 명세서 v3.0 §1.3)
@@ -42,25 +47,31 @@ import java.io.IOException;
  *   /nurse/**             간호사             ROLE_NURSE, ROLE_ADMIN (§7)
  *   /admin/**             관리자             ROLE_ADMIN 전용 (§9~§14)
  *
- * ■ 로그인 성공 리다이렉트 (§2.2)
- *   ROLE_ADMIN  → /admin/dashboard
- *   ROLE_DOCTOR → /doctor/dashboard
- *   ROLE_NURSE  → /nurse/dashboard
- *   ROLE_STAFF  → /staff/dashboard
- *
- * ■ UserDetailsService
- *   InMemoryUserDetailsManager (테스트: admin01, staff01, doctor01, nurse01 / password123)
+ * ■ 보안 설정
+ *   - CORS: 허용 Origin 화이트리스트 (환경변수 설정 가능)
+ *   - CSRF: SSR 폼 보호 활성화, /llm/symptom/** 만 제외
+ *   - Security Headers: CSP, HSTS, Referrer-Policy, Permissions-Policy
+ *   - Rate Limiting: RateLimitFilter (IP 기반 토큰 버킷)
+ *   - 로그인 실패: 사용자 열거 방지 (일관된 에러 메시지)
  * ════════════════════════════════════════════════════════════════════════════
  */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    /** CORS 허용 Origin — 환경변수 또는 기본값 (개발: localhost:8080) */
+    @Value("${hms.cors.allowed-origins:http://localhost:8080}")
+    private String allowedOrigins;
+
+    private final RateLimitFilter rateLimitFilter;
+
+    public SecurityConfig(RateLimitFilter rateLimitFilter) {
+        this.rateLimitFilter = rateLimitFilter;
+    }
+
     // ════════════════════════════════════════════════════════════════════════
     // H2 Console Security Filter Chain (개발용)
     // ════════════════════════════════════════════════════════════════════════
-    // H2 콘솔은 별도 서블릿이므로 MvcRequestMatcher로 매칭 불가.
-    // PathRequest.toH2Console()을 사용하는 전용 필터 체인 필요.
 
     @Bean
     @Order(1)
@@ -81,13 +92,34 @@ public class SecurityConfig {
     @Order(2)
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-            // ── CSRF ─────────────────────────────────────────────────────
+            // ── CORS ────────────────────────────────────────────────────
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+            // ── CSRF ────────────────────────────────────────────────────
             // SSR(Mustache) 폼 제출 보호 활성화.
-            // LLM AJAX 엔드포인트(JSON 전용)는 제외 — JS fetch 호출 시 CSRF 헤더 불필요.
-            // 폼 제출 엔드포인트는 Mustache 템플릿에 {{_csrf.token}} 포함 필요.
+            // 비회원 LLM 증상 분석 AJAX(JSON 전용)만 제외.
+            // /llm/rules/** 는 인증 필요 엔드포인트이므로 CSRF 보호 유지.
+            // JS fetch 호출 시 CSRF 토큰을 X-CSRF-TOKEN 헤더로 전송 필요.
             .csrf(csrf -> csrf
-                .ignoringRequestMatchers("/llm/**")
+                .ignoringRequestMatchers("/llm/symptom/**")
             )
+
+            // ── Security Headers ────────────────────────────────────────
+            .headers(headers -> headers
+                .contentSecurityPolicy(csp -> csp
+                    .policyDirectives("default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; frame-ancestors 'self'")
+                )
+                .httpStrictTransportSecurity(hsts -> hsts
+                    .maxAgeInSeconds(31536000)
+                    .includeSubDomains(true)
+                )
+                .referrerPolicy(referrer -> referrer
+                    .policy(org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN)
+                )
+            )
+
+            // ── Rate Limiting Filter ────────────────────────────────────
+            .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
 
             // ── URL별 접근 권한 ───────────────────────────────────────────
             .authorizeHttpRequests(auth -> auth
@@ -133,7 +165,7 @@ public class SecurityConfig {
                 .usernameParameter("username")
                 .passwordParameter("password")
                 .successHandler(roleBasedSuccessHandler()) // 역할별 대시보드 리다이렉트
-                .failureUrl("/login?error=true")           // 실패 시 (§2.2)
+                .failureHandler(loginFailureHandler())     // 사용자 열거 방지 — 일관된 에러 메시지
                 .permitAll()
             )
 
@@ -147,17 +179,12 @@ public class SecurityConfig {
             )
 
             // ── 세션 관리 ─────────────────────────────────────────────────
-            // 동일 계정 최대 세션 1개.
-            // maxSessionsPreventsLogin(false): 새 로그인 시 기존 세션 만료 (타 기기 자동 로그아웃).
-            // HttpSessionEventPublisher Bean 등록 필수 (아래 참고).
             .sessionManagement(session -> {
                 session.maximumSessions(1)
                        .maxSessionsPreventsLogin(false);
             })
 
             // ── 인증·인가 오류 처리 (§1.6) ───────────────────────────────
-            // 미로그인 접근(401): Spring Security가 자동으로 /login 리다이렉트.
-            // 권한 없는 접근(403): /error/403 화면 렌더링.
             .exceptionHandling(ex -> ex
                 .accessDeniedPage("/error/403")
             )
@@ -171,13 +198,6 @@ public class SecurityConfig {
 
     /**
      * 로그인 성공 시 ROLE별 대시보드로 리다이렉트 (API 명세서 §2.2).
-     *
-     * <pre>
-     * ROLE_ADMIN  → /admin/dashboard
-     * ROLE_DOCTOR → /doctor/dashboard
-     * ROLE_NURSE  → /nurse/dashboard
-     * ROLE_STAFF  → /staff/dashboard
-     * </pre>
      */
     @Bean
     AuthenticationSuccessHandler roleBasedSuccessHandler() {
@@ -206,28 +226,45 @@ public class SecurityConfig {
     }
 
     /**
+     * 로그인 실패 핸들러 — 사용자 열거 방지 (§2.2)
+     * 아이디 미존재 / 비밀번호 불일치 / 비활성 계정 모두 동일 에러 파라미터 전달.
+     */
+    @Bean
+    SimpleUrlAuthenticationFailureHandler loginFailureHandler() {
+        return new SimpleUrlAuthenticationFailureHandler("/login?error=true");
+    }
+
+    /**
      * BCrypt 패스워드 인코더.
      * Staff 등록(§10.3) 및 비밀번호 수정 시 암호화에 사용.
-     * UserDetailsService 구현체에서 주입받아 사용.
      */
     @Bean
     PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    /**
+     * CORS 설정 — 허용 Origin 화이트리스트.
+     * 환경변수 hms.cors.allowed-origins 로 쉼표 구분 Origin 지정 가능.
+     * 기본값: http://localhost:8080 (개발용)
+     */
     @Bean
-    InMemoryUserDetailsManager userDetailsService(PasswordEncoder encoder) {
-        UserDetails admin = User.builder().username("admin01").password(encoder.encode("password123")).roles("ADMIN").build();
-        UserDetails staff = User.builder().username("staff01").password(encoder.encode("password123")).roles("STAFF").build();
-        UserDetails doctor = User.builder().username("doctor01").password(encoder.encode("password123")).roles("DOCTOR").build();
-        UserDetails nurse = User.builder().username("nurse01").password(encoder.encode("password123")).roles("NURSE").build();
-        return new InMemoryUserDetailsManager(admin, staff, doctor, nurse);
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(allowedOrigins.split(",")));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("Content-Type", "X-CSRF-TOKEN", "Authorization"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 
     /**
      * 세션 동시성 제어를 위한 이벤트 퍼블리셔.
      * sessionManagement().maximumSessions() 동작에 필수.
-     * 세션 생성·소멸 이벤트를 Spring Security가 감지하여 동시 세션을 관리함.
      */
     @Bean
     HttpSessionEventPublisher httpSessionEventPublisher() {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -58,5 +58,5 @@ logging.pattern.console=%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
 # ------------------------------------------------------------------------------
 # 에러 페이지 (개발: 상세 노출)
 # ------------------------------------------------------------------------------
-server.error.include-message=always
-server.error.include-stacktrace=always
+server.error.include-message=on_param
+server.error.include-stacktrace=never

--- a/src/main/resources/application-prod.properties.example
+++ b/src/main/resources/application-prod.properties.example
@@ -69,7 +69,12 @@ logging.file.max-size=50MB
 logging.file.max-history=90
 
 # ------------------------------------------------------------------------------
+# 세션 쿠키 보안 (운영: HTTPS 필수)
+# ------------------------------------------------------------------------------
+server.servlet.session.cookie.secure=true
+
+# ------------------------------------------------------------------------------
 # 에러 페이지 (운영: 스택트레이스 비노출)
 # ------------------------------------------------------------------------------
-server.error.include-message=always
+server.error.include-message=never
 server.error.include-stacktrace=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,13 @@ spring.mustache.servlet.expose-request-attributes=true
 spring.mustache.servlet.allow-request-override=true
 
 # ------------------------------------------------------------------------------
+# 공통 세션 쿠키 보안
+# ------------------------------------------------------------------------------
+server.servlet.session.cookie.http-only=true
+server.servlet.session.cookie.secure=false
+server.servlet.session.cookie.same-site=Lax
+
+# ------------------------------------------------------------------------------
 # 공통 파일 업로드 제한
 # ------------------------------------------------------------------------------
 spring.servlet.multipart.max-file-size=10MB


### PR DESCRIPTION
- InMemoryUserDetailsManager → DB 기반 CustomUserDetailsService 교체 (#2, #10)
- CORS 명시 설정 추가 (CorsConfigurationSource 빈, Origin 화이트리스트) (#5)
- CSRF 범위 축소: /llm/** → /llm/symptom/** 만 제외 (#6)
- Security Headers 추가: CSP, HSTS, Referrer-Policy (#9)
- IP 기반 RateLimitFilter 추가 (로그인 10회/분, LLM 20회/분) (#8)
- 세션 쿠키 보안: HttpOnly, SameSite=Lax 설정 (#7)
- 스택트레이스 외부 비노출 (dev/prod) (#3)
- 로그인 실패 핸들러 통일 (사용자 열거 방지) (#12)
- prod 에러 메시지 비노출, 쿠키 secure=true (#11)
- IDOR 방지 가이드 주석 추가 (SampleReservationService) (#13)