### PR TITLE
fix: 비회원 예약 API 경로 permitAll 추가

### DIFF
--- a/src/main/java/com/smartclinic/hms/config/SecurityConfig.java
+++ b/src/main/java/com/smartclinic/hms/config/SecurityConfig.java
@@ -137,7 +137,7 @@ public class SecurityConfig {
                         .requestMatchers("/login", "/logout").permitAll()
 
                         // ── 비회원 메인·외부 예약 (§3) ──────────────────────────
-                        .requestMatchers("/", "/reservation/**").permitAll()
+                        .requestMatchers("/", "/reservation/**", "/api/reservation/**").permitAll()
 
                         // ── LLM 증상 분석 — 비회원 AJAX (§4) ───────────────────
                         .requestMatchers("/llm/symptom/**").permitAll()


### PR DESCRIPTION
## Summary
- SecurityConfig에서 `/api/reservation/**` 경로를 `permitAll`에 추가
- 비회원 예약 API 접근이 차단되던 문제 해결

## Test plan
- [ ] 비로그인 상태에서 `/api/reservation/**` API 호출 시 정상 응답 확인
- [ ] 기존 인증 필요 경로는 여전히 보호되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)