### PR TITLE
Feture/admin docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
 
 	// Compile-only (빌드 시에만 필요)
 	compileOnly 'org.projectlombok:lombok'

--- a/doc/CODE_REVIEW_2026-03-25.md
+++ b/doc/CODE_REVIEW_2026-03-25.md
@@ -1,0 +1,321 @@
+# 코드 리뷰 보고서
+
+**리뷰 대상:** `feature/dev-a` 브랜치 전체 코드베이스
+**리뷰 일자:** 2026-03-25 (2차 업데이트 — 커밋 `de37d49` 반영)
+**리뷰 기준:** `doc/rules/` 규칙 문서 6종 + 아키텍처/보안/성능 종합
+**총 이슈:** 29건 (CRITICAL 3건 / HIGH 12건 / MEDIUM 9건 / LOW 5건)
+
+---
+
+## 팀 구성 및 코드 소유권
+
+
+| 역할           | 이름  | 담당 영역                                                                                                  |
+| ------------ | --- | ------------------------------------------------------------------------------------------------------ |
+| 책임개발자 (Lead) | 김민구 | `config/`**, `common/**`, `domain/**`, `llm/**`, `application*.properties`, `templates/common/**`      |
+| 개발자 A        | 강태오 | `reservation/**`, `home/**`, `templates/reservation/**`, `templates/home/**`                           |
+| 개발자 B        | 조유지 | `staff/**`, `doctor/**`, `nurse/**`, `templates/staff/**`, `templates/doctor/**`, `templates/nurse/**` |
+| 개발자 C        | 강상민 | `admin/**`, `item/**`, `templates/admin/**`                                                            |
+
+
+---
+
+## 2026-03-23 리뷰 이후 수정 완료 항목
+
+
+| ID   | 이슈                                         | 수정 내용                                                                                          |
+| ---- | ------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| H-02 | ReservationApiController Resp.ok() 미사용      | 세 엔드포인트 모두 `ResponseEntity<Resp<T>>` + `Resp.ok()` 방식으로 수정 완료                                  |
+| H-03 | ReservationController.symptomReservation() Model 사용 | `HttpServletRequest request`로 교체 완료                                                     |
+| M-01 | ReservationApiController 응답 포맷 불일치         | `Resp.ok()` 방식으로 통일 완료                                                                        |
+| M-02 | ReservationCompleteInfo 일반 클래스             | Java Record로 변환 완료                                                                            |
+| M-09 | ReservationRepository.countByCreatedAtBetween() 미사용 | 메서드 제거 완료                                                                              |
+| M-03 | AdminDashboardStatsService LocalDate.now() | `getDashboardStats(LocalDate)` / `getDashboardChart(LocalDate)` 오버로딩 추가로 테스트 가능성 개선 (부분 수정) |
+
+
+---
+
+## 심각도 요약
+
+
+| 심각도      | 건수  | 이월  | 신규  | 상태    | 조치 기준       |
+| -------- | --- | --- | --- | ----- | ----------- |
+| CRITICAL | 3   | 2   | 1   | 수정 필수 | 병합 전 반드시 수정 |
+| HIGH     | 12  | 9   | 3   | 수정 필요 | 병합 전 수정 권장  |
+| MEDIUM   | 9   | 7   | 2   | 수정 권장 | 가능한 빨리 수정   |
+| LOW      | 5   | 5   | 0   | 참고    | 일정 여유 시 수정  |
+
+
+---
+
+## Part 1. 규칙 준수 점검 (doc/rules/ 6종)
+
+### 1.1 rule-controller.md 준수 점검
+
+
+| #   | 규칙                                                     | 준수    | 위반 내용                                                                                                                         | 담당자     |
+| --- | ------------------------------------------------------ | ----- | ------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| 1   | SSR Controller는 String(뷰 경로) 반환                        | **X** | `DoctorTreatmentController`, `ReceptionController`, `WalkinController` — `@Controller` 클래스에 `@ResponseBody` REST 반환 공존         | **조유지** |
+| 2   | API Controller는 ResponseEntity + Resp.ok() 사용          | **X** | `AdminItemController.useItem()` — `Map.of()` 방식. `ReceptionController` AJAX 엔드포인트 — `Map<String,Object>` 직접 반환. Resp 미사용      | **조유지** / **강상민** |
+| 3   | Controller는 Service만 호출 (Repository 직접 호출 금지)          | O     | 전 영역 준수 확인                                                                                                                    | -       |
+| 4   | DTO 네이밍: Request/Response 규칙                           | O     | 전 영역 준수                                                                                                                       | -       |
+| 5   | 비즈니스 로직이 Controller에 없을 것                              | **X** | `ReceptionController.list()` — 페이징 처리, 탭 필터링, 파라미터 빌딩 등 200줄 이상의 비즈니스/뷰 로직이 Controller에 직접 구현됨                              | **조유지** |
+| 6   | 예외 응답은 GlobalExceptionHandler / SsrExceptionHandler 사용 | O     | 전 영역 준수                                                                                                                       | -       |
+| 7   | GET SSR 핸들러는 HttpServletRequest 사용                     | **X** | `DoctorTreatmentController`, `ReceptionController`, `WalkinController`, `PhoneReservationController` — GET 핸들러에 `Model model` 사용 | **조유지** |
+
+
+### 1.2 rule-repository.md 준수 점검
+
+
+| #   | 규칙                                    | 준수    | 위반 내용                                                                                                           | 담당자            |
+| --- | ------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------- | -------------- |
+| 1   | Repository는 소유 기능 모듈 패키지에 배치          | O     | 각 모듈별 Repository가 해당 패키지에 위치                                                                                    | -              |
+| 2   | JpaRepository 인터페이스 기반 작성             | O     | 모든 Repository가 JpaRepository 상속                                                                                 | -              |
+| 3   | 쿼리 우선순위: 파생 메서드 > Projection > @Query | **X** | `AdminReservationRepository`, `AdminStaffRepository`에서 nativeQuery 다수 사용 — 이월 미수정                               | **강상민**        |
+| 4   | 다중 도메인 집계는 Service 조합 처리              | O     | 준수                                                                                                              | -              |
+| 5   | 동일 엔티티 중복 Repository 방지               | **X** | `Reservation` 4개, `Patient` 3개, `Staff` 2개, `Department` 2개 Repository 중복 — 이월 미수정                             | **김민구** (아키텍처) |
+| 6   | EntityManager 직접 사용 금지                | O     | 준수                                                                                                              | -              |
+
+
+### 1.3 rule_spring.md 준수 점검
+
+
+| #   | 규칙                                           | 준수    | 위반 내용                                                                                                      | 담당자     |
+| --- | -------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------- | ------- |
+| 1   | 환경 변수로 민감 정보 관리                              | O     | API 키 환경변수 사용                                                                                             | -       |
+| 2   | 전역 에러 핸들러 ErrorResponse 포맷 통일                | **X** | `ReceptionController` AJAX — `Map<String,Object>` 직접 반환. `AdminItemController.useItem()` — `Map.of()` 반환 | **조유지** / **강상민** |
+| 3   | 비즈니스 예외는 CustomException 사용                  | O     | 전 영역 준수                                                                                                   | -       |
+| 4   | Service 클래스 레벨 @Transactional(readOnly=true) | O     | 모든 Service 일관 적용                                                                                          | -       |
+| 5   | DTO는 Java Record 우선                          | O     | `ReservationCompleteInfo` Record 변환 완료                                                                    | -       |
+| 6   | @Valid로 요청 검증                                | O     | 주요 POST 엔드포인트 `@Valid` 적용                                                                                | -       |
+| 7   | 페이징은 Pageable 기본 사용                          | **X** | `ReceptionController.list()` — Pageable 미사용. 직접 `subList()` + 수동 페이지 계산으로 서비스 레이어 없이 Controller에서 처리 | **조유지** |
+
+
+### 1.4 rule_test.md 준수 점검
+
+
+| #   | 규칙                                       | 준수    | 위반 내용                                                                                             | 담당자               |
+| --- | ---------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------- | ----------------- |
+| 1   | 핵심 로직에 대한 테스트 존재                         | **X** | `LlmReservationService`, `SymptomAnalysisService`, `DoctorTreatmentService` 단위 테스트 전무 — 이월 미수정      | **김민구** / **조유지** |
+| 2   | LocalDateTime.now() 직접 사용 금지 (Clock 추상화) | **X** | `NurseService:37`, `ReceptionService:178`, `DoctorTreatmentService:34,106` 등 다수 — 이월 미수정          | **조유지** / **강상민** |
+| 3   | Given-When-Then 주석 필수                    | O     | 모든 테스트 준수                                                                                          | -                 |
+| 4   | BDDMockito given().willReturn() 사용       | O     | 전 테스트 파일 준수                                                                                        | -                 |
+| 5   | @DisplayName 필수                          | O     | 전 테스트 파일 준수                                                                                        | -                 |
+| 6   | TestSecurityConfig 중복 방지                 | **X** | 10개 이상 WebMvcTest 클래스에 동일한 `TestSecurityConfig` 내부 클래스 반복 선언 — 이월 미수정                            | **김민구** (공통)      |
+
+
+### 1.5 rule_css.md 준수 점검
+
+
+| #   | 규칙             | 준수    | 위반 내용                                                                                                        | 담당자               |
+| --- | -------------- | ----- | ------------------------------------------------------------------------------------------------------------ | ----------------- |
+| 1   | BEM 네이밍 규칙     | O     | `common.css` BEM 패턴 사용                                                                                       | -                 |
+| 2   | CSS 변수 사용      | O     | `:root` 기반 CSS 변수 사용                                                                                        | -                 |
+| 3   | id 셀렉터 사용 금지   | O     | 미사용 확인                                                                                                      | -                 |
+| 4   | 재사용 가능한 단위로 분리 | **X** | `admin-style.css` = `style-admin.css`, `doctor-style.css` = `style-doctor.css` 100% 동일 — 이월 미수정              | **강상민** / **조유지** |
+| 5   | 인라인 스타일 금지     | O     | Mustache 템플릿 인라인 style 미사용                                                                                 | -                 |
+
+
+### 1.6 rule_javascript.md 준수 점검
+
+
+| #   | 규칙                              | 준수    | 위반 내용                                                                                                                | 담당자               |
+| --- | ------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| 1   | var 사용 금지                       | **X** | `admin-rule-form.js`, `admin-staff-form.js`, `doctor-treatment-detail.js`, `staff-reception-detail.js` 등 — 이월 미수정      | **조유지** / **강상민** |
+| 2   | const 우선 사용                     | O     | 대부분 신규 파일 const/let 사용                                                                                              | -                 |
+| 3   | async/await 기본                  | O     | 준수                                                                                                                    | -                 |
+| 4   | fetch 응답 에러 처리                  | O     | 주요 fetch 호출 response.ok 검사                                                                                          | -                 |
+| 5   | 전역 변수 금지                        | **X** | `data-admin.js`, `data-staff.js` 등 전역 함수 중복 — 이월 미수정                                                               | **전원**            |
+| 6   | innerHTML 직접 사용 금지 (XSS)        | **X** | `admin-rule-form.js:6-8`, `staff-reception-detail.js:3`, `doctor-treatment-detail.js:9`, `admin-dashboard.js:225,229` | **강상민** / **조유지** |
+
+
+---
+
+## Part 2. 이슈 상세 및 담당자 배정
+
+### CRITICAL (3건) — 병합 전 반드시 수정
+
+
+| ID   | 이슈                                                                                                                                                                                                                    | 위반 규칙               | 위치                                                                                                    | 담당자               | 구분       |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- | ----------------- | -------- |
+| C-01 | **tools.jackson 비표준 import** — `tools.jackson.core.JacksonException`, `tools.jackson.databind.ObjectMapper` 사용. Spring Boot 번들 `com.fasterxml.jackson`과 충돌 시 런타임 `ClassNotFoundException` 발생 위험. **3주 연속 미수정**       | rule_spring (1)     | `llm/service/MedicalService.java:22-23`                                                                 | **김민구**           | 이월 (3주) |
+| C-02 | **innerHTML XSS 취약점** — SVG 아이콘/스피너 고정 문자열이나 패턴 확산 시 XSS 경로 노출. `lucide.createIcons()` API 또는 `createElement` + `textContent`로 교체 필요. **3주 연속 미수정**                                                              | rule_javascript (6) | `admin-rule-form.js:6-8`, `staff-reception-detail.js:3`, `doctor-treatment-detail.js:9`, `admin-dashboard.js:225,229` | **강상민** / **조유지** | 이월 (3주) |
+| C-03 | **AdminStaffService 문자열 상수 인코딩 깨짐** — `STAFF_CREATED_MESSAGE`, `STAFF_UPDATED_MESSAGE` 등 14개 상수(lines 55-68)가 깨진 바이트열로 저장됨. 런타임에 사용자에게 의미 없는 문자가 그대로 노출됨. `INACTIVE_STAFF_UPDATE_NOT_ALLOWED_MESSAGE`(line 69)부터는 정상 Unicode 이스케이프 사용. 파일 UTF-8 재저장 + 상수 올바른 문자열로 수정 필요 | -  | `admin/staff/AdminStaffService.java:55-68`                                                              | **강상민**           | 신규       |
+
+
+### HIGH (12건) — 병합 전 수정 권장
+
+
+| ID     | 이슈                                                                                                                                                                                                           | 위반 규칙                | 위치                                                                           | 담당자               | 구분  |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------- | ------------------------------------------------------------------------------ | ----------------- | --- |
+| H-01   | **동일 Entity에 다중 Repository** — `Reservation` 4개, `Patient` 3개, `Staff` 2개, `Department` 2개. 쿼리 중복, 변경 시 누락 위험. **이월 미수정**                                                                                   | rule-repository (5)  | `reservation/`, `admin/`, `nurse/`, `staff/` 패키지 전체                           | **김민구**           | 이월  |
+| H-04   | **AdminItemController SSR/REST 혼재** — `@Controller` 클래스에 `@PostMapping("/use") @ResponseBody`. `Resp.ok()` 미사용. **이월 미수정**                                                                                   | rule-controller (1,2) | `admin/item/AdminItemController.java:108-131`                                  | **강상민**           | 이월  |
+| H-05   | **ReceptionService 중복 체크 비효율** — `createPhoneReservation()`에서 당일 전체 예약 로드 후 Java 스트림 필터링. 단일 쿼리로 충분. **이월 미수정**                                                                                             | rule_spring (8)      | `staff/reception/ReceptionService.java:92-98`                                  | **조유지**           | 이월  |
+| H-06   | **ReceptionService.getReservations() N+1** — 스트림 내부에서 건별로 `countByPatient_IdAndStatus()` 호출(초재진 판별). 예약 100건 → DB 쿼리 101번 발생. **이월 미수정**                                                                    | rule_spring (8)      | `staff/reception/ReceptionService.java:218`                                    | **조유지**           | 이월  |
+| H-07   | **NurseService.getPatientDetail() N+1** — 히스토리 루프 내부에서 건별로 `treatmentRecordRepository.findByReservation_Id()` 호출. **이월 미수정**                                                                                | rule_spring (8)      | `nurse/NurseService.java:211`                                                  | **조유지**           | 이월  |
+| H-08   | **역할별 CSS 중복 파일** — `admin-style.css` = `style-admin.css`, `doctor-style.css` = `style-doctor.css` 100% 동일. **이월 미수정**                                                                                       | rule_css (4)         | `static/css/admin-style.css`, `style-admin.css`, `doctor-style.css` 외          | **강상민** / **조유지** | 이월  |
+| H-09   | **NurseReceptionController SSR/REST 혼재** — `@Controller` 클래스에 `/item/use`, `/item/cancel` `@ResponseBody` 엔드포인트. **이월 미수정**                                                                                 | rule-controller (1)  | `nurse/NurseReceptionController.java:382-415`                                  | **조유지**           | 이월  |
+| N-H-01 | **DoctorTreatmentController SSR/REST 혼재** — `@Controller` 클래스에 `poll`, 아이템 사용 `@ResponseBody` 엔드포인트. **이월 미수정**                                                                                             | rule-controller (1)  | `doctor/treatment/DoctorTreatmentController.java:36-42`                        | **조유지**           | 이월  |
+| N-H-02 | **DoctorTreatmentController GET 핸들러 Model 사용** — `treatmentList()` 등 GET SSR 핸들러 `Model model` 사용. **이월 미수정**                                                                                                | rule-controller (7)  | `doctor/treatment/DoctorTreatmentController.java:44-50`                        | **조유지**           | 이월  |
+| N-H-03 | **ReceptionController SSR/REST 혼재 + Resp 미사용** — `@Controller` 클래스에 `receiveAjax`, `cancelAjax`, `payAjax`, `updatePatientInfo` 등 4개 `@ResponseBody` 엔드포인트 추가. `Map<String,Object>` 직접 반환으로 `Resp.ok()` 미준수 | rule-controller (1,2) | `staff/reception/ReceptionController.java:273-337`                             | **조유지**           | 신규  |
+| N-H-04 | **GET SSR 핸들러 Model 사용 확산** — `ReceptionController.list()`(line 41), `ReceptionController.detail()`(line 224), `WalkinController.walkinPage()`(line 33), `PhoneReservationController.phoneReservation()`(line 31) 모두 `Model model` 파라미터 사용 | rule-controller (7) | `ReceptionController.java`, `WalkinController.java`, `PhoneReservationController.java` | **조유지** | 신규  |
+| N-H-05 | **ReceptionController 비즈니스 로직 Controller 침투** — `list()` 메서드에 탭별 필터링, 수동 페이징(subList), 파라미터 빌더, 상태 텍스트 변환 등 200줄 이상의 로직 직접 구현. Service로 위임 및 `Pageable` 사용 필요 | rule-controller (5), rule_spring (7) | `staff/reception/ReceptionController.java:41-221`                     | **조유지**           | 신규  |
+
+
+### MEDIUM (9건) — 가능한 빨리 수정
+
+
+| ID     | 이슈                                                                                                                                                              | 위반 규칙               | 위치                                                                                                            | 담당자               | 구분  |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------- | --- |
+| M-03   | **LocalDateTime.now() 직접 호출** — `NurseService:37`, `ReceptionService:178,303`, `DoctorTreatmentService:34,106` 등. `AdminDashboardStatsService`는 오버로딩으로 부분 개선됨 | rule_test (2)       | `nurse/NurseService.java`, `staff/reception/ReceptionService.java`, `doctor/treatment/DoctorTreatmentService.java` | **조유지** / **강상민** | 이월  |
+| M-04   | **TestSecurityConfig 10중 중복** — 10개 이상 `@WebMvcTest` 클래스에 동일한 내부 클래스 반복. `test/common/`으로 추출 필요. **이월 미수정**                                                      | rule_test (6)       | `src/test/` 전체                                                                                                  | **김민구**           | 이월  |
+| M-05   | **LlmReservationService/SymptomAnalysisService 단위 테스트 전무** — 핵심 LLM 로직 테스트 없음. **이월 미수정**                                                                      | rule_test (1)       | `src/test/java/.../llm/`                                                                                         | **김민구**           | 이월  |
+| M-06   | **var 키워드 사용** — `admin-rule-form.js`, `doctor-treatment-detail.js`, `staff-reception-detail.js` 등 다수. **이월 미수정**                                               | rule_javascript (1) | `static/js/pages/` 전체                                                                                           | **조유지** / **강상민** | 이월  |
+| M-07   | **_sample 패키지 운영 빌드 포함** — `SampleReservation` 엔티티 DDL 운영 환경 실행. **이월 미수정**                                                                                   | rule_spring (1)     | `_sample/` 패키지                                                                                                  | **김민구**           | 이월  |
+| M-08   | **NurseService.toKoreanDayOfWeek() 미사용 메서드** — private 선언이나 미호출. **이월 미수정**                                                                                   | -                   | `nurse/NurseService.java:86-97`                                                                                  | **조유지**           | 이월  |
+| N-M-01 | **admin-dashboard.js innerHTML 사용** — `container.innerHTML = renderItemFlowEmptyState()` 및 템플릿 리터럴 할당. 서버 데이터 포함 시 XSS 위험. **이월 미수정**                          | rule_javascript (6) | `static/js/pages/admin-dashboard.js:225,229`                                                                     | **강상민**           | 이월  |
+| N-M-02 | **DoctorTreatmentService LocalDate.now() 직접 사용** — 6곳에서 `LocalDate.now()` 직접 호출. **이월 미수정**                                                                    | rule_test (2)       | `doctor/treatment/DoctorTreatmentService.java:34,106,118,167,183,228`                                            | **조유지**           | 이월  |
+| N-M-03 | **InactiveStaffLogoutInterceptor 매 요청 DB 조회** — 모든 인증된 요청마다 `staffRepository.findByUsername()` 호출. 고트래픽 시 DB 부하 증가. Spring Security의 세션 어트리뷰트 캐싱 또는 `@EventListener(SessionDestroyedEvent)` 활용 권장 | - | `common/interceptor/InactiveStaffLogoutInterceptor.java:31`                                                      | **김민구**           | 신규  |
+| N-M-04 | **AdminStaffController 메시지 contains 기반 오류 라우팅** — `applyCreateViewErrors()`, `applyUpdateViewErrors()`에서 `ex.getMessage().contains("부서")` 등 문자열 포함 여부로 오류 유형 판별. 메시지 변경 시 라우팅 깨질 수 있음. 전용 에러 코드 기반으로 분기 필요 | - | `admin/staff/AdminStaffController.java:138-183`                                                                  | **강상민**           | 신규  |
+
+
+### LOW (5건) — 참고
+
+
+| ID   | 이슈                                                                                                                                 | 위치                                                                             | 담당자     |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------- |
+| L-01 | **doctor.availableDays 문자열 저장 — 정규화 없음** — 공백 포함 입력 시 조용히 null 필터링. 연관 테이블 정규화 권장                                                  | `domain/Doctor.java`                                                           | **김민구** |
+| L-02 | **LayoutModelInterceptor 26개 boolean 플래그** — `path.contains()` 방식 혼용으로 부정확한 매칭 가능. enum 기반 리팩터링 권장                                  | `common/interceptor/LayoutModelInterceptor.java:71-103`                        | **김민구** |
+| L-03 | **StaffRole enum switch 중복** — `SecurityConfig`, `LayoutModelInterceptor` 양쪽에 동일 switch 반복. enum에 `getDashboardUrl()` 추가로 제거 가능     | `config/SecurityConfig.java`, `common/interceptor/LayoutModelInterceptor.java` | **김민구** |
+| L-04 | **전역 JS 함수 중복 정의** — `data-admin.js`, `data-staff.js`, `data-nurse.js` 전역 함수 중복. 대부분 죽은 코드                                          | `static/js/data-*.js`                                                          | **전원**  |
+| L-05 | **AdminReservationRepository nativeQuery 사용** — JPQL 또는 파생 메서드로 대체 가능                                                             | `admin/reservation/AdminReservationRepository.java`                            | **강상민** |
+
+
+---
+
+## Part 3. 담당자별 수정 사항 요약
+
+### 김민구 (책임개발자/Lead) — 9건
+
+
+| 우선순위     | ID     | 수정 사항                                                                                     |
+| -------- | ------ | ----------------------------------------------------------------------------------------- |
+| CRITICAL | C-01   | `MedicalService.java` `tools.jackson` → `com.fasterxml.jackson` 경로 수정                    |
+| HIGH     | H-01   | 동일 Entity 다중 Repository 통합 — 단일 공용 Repository + 패키지별 Service 쿼리 호출                      |
+| MEDIUM   | M-04   | `TestSecurityConfig` 공통 추출 — `test/common/` 패키지에 공유 설정 클래스 작성                           |
+| MEDIUM   | M-05   | `LlmReservationService`, `SymptomAnalysisService` 단위 테스트 작성                               |
+| MEDIUM   | M-07   | `_sample/` 패키지 `@Profile("dev")` 또는 테스트 소스셋 이동                                          |
+| MEDIUM   | N-M-03 | `InactiveStaffLogoutInterceptor` — 매 요청 DB 조회를 세션 어트리뷰트 캐싱으로 개선                         |
+| LOW      | L-01   | `availableDays` 정규화 개선 검토                                                                |
+| LOW      | L-02   | `LayoutModelInterceptor` boolean 플래그 정리                                                  |
+| LOW      | L-03   | `StaffRole` enum에 `getDashboardUrl()` 추가로 switch 중복 제거                                   |
+
+
+### 강태오 (개발자 A) — 0건
+
+> 배정 이슈 전부 수정 완료. 이번 리뷰 신규 배정 이슈 없음. 유지 상태 양호.
+
+
+### 조유지 (개발자 B) — 14건
+
+
+| 우선순위     | ID     | 수정 사항                                                                                                           |
+| -------- | ------ | ----------------------------------------------------------------------------------------------------------------- |
+| CRITICAL | C-02   | `staff-reception-detail.js`, `doctor-treatment-detail.js` `btn.innerHTML` → `textContent` 교체                     |
+| HIGH     | H-05   | `ReceptionService.createPhoneReservation()` 중복 체크 → `existsByDoctor_IdAndReservationDateAndTimeSlotAndStatusNot()` 단일 쿼리 |
+| HIGH     | H-06   | `ReceptionService.getReservations()` N+1 — 배치 조회 또는 Projection으로 개선                                             |
+| HIGH     | H-07   | `NurseService.getPatientDetail()` N+1 — `findAllByReservation_IdIn()` 배치 조회                                      |
+| HIGH     | H-09   | `NurseReceptionController` → 별도 `NurseItemApiController`(@RestController)로 분리                                    |
+| HIGH     | N-H-01 | `DoctorTreatmentController` → `DoctorTreatmentApiController`(@RestController) 분리                                  |
+| HIGH     | N-H-02 | `DoctorTreatmentController` GET 핸들러 `Model` → `HttpServletRequest` 교체                                           |
+| HIGH     | N-H-03 | `ReceptionController` AJAX 엔드포인트 → 별도 `ReceptionApiController`(@RestController) + `Resp.ok()` 분리               |
+| HIGH     | N-H-04 | `ReceptionController`, `WalkinController`, `PhoneReservationController` GET 핸들러 `Model` → `HttpServletRequest` 교체 |
+| HIGH     | N-H-05 | `ReceptionController.list()` 비즈니스 로직 → Service로 위임 + `Pageable` 사용으로 수동 페이징 제거                                |
+| MEDIUM   | M-03   | `NurseService`, `ReceptionService`, `DoctorTreatmentService` `LocalDate.now()` → `Clock` 주입                      |
+| MEDIUM   | M-06   | 담당 JS 파일 `var` → `const`/`let` 전환                                                                               |
+| MEDIUM   | M-08   | `NurseService.toKoreanDayOfWeek()` 미사용 메서드 제거                                                                   |
+| MEDIUM   | N-M-02 | `DoctorTreatmentService` `LocalDate.now()` → `Clock` 주입                                                          |
+
+
+### 강상민 (개발자 C) — 9건
+
+
+| 우선순위     | ID     | 수정 사항                                                                                                 |
+| -------- | ------ | ------------------------------------------------------------------------------------------------------- |
+| CRITICAL | C-02   | `admin-rule-form.js` `innerHTML` → `lucide.createIcons()` API 교체                                       |
+| CRITICAL | C-03   | `AdminStaffService.java:55-68` 깨진 문자열 상수 — 파일 UTF-8 재저장 + 올바른 문자열로 수정                              |
+| HIGH     | H-04   | `AdminItemController.useItem()` → `AdminItemApiController`(@RestController) + `Resp.ok()` 분리            |
+| HIGH     | H-08   | `admin-style.css`, `style-admin.css` 등 중복 CSS 파일 통합 삭제                                               |
+| MEDIUM   | M-03   | `AdminItemController.resolveDateRange()`의 `LocalDate.now()` — `AdminDashboardStatsService` 오버로딩 패턴 동일 적용 |
+| MEDIUM   | M-06   | 담당 JS 파일 `var` → `const`/`let` 전환                                                                     |
+| MEDIUM   | N-M-01 | `admin-dashboard.js` `innerHTML` → `createElement` + `textContent` 교체                                  |
+| MEDIUM   | N-M-04 | `AdminStaffController` 메시지 contains 판별 → 에러 코드 기반 분기로 교체                                             |
+| LOW      | L-05   | `AdminReservationRepository` nativeQuery → JPQL 전환                                                     |
+
+
+### 전원 공동 — 1건
+
+
+| 우선순위 | ID   | 수정 사항                                                              |
+| ---- | ---- | ------------------------------------------------------------------ |
+| LOW  | L-04 | `data-admin.js`, `data-staff.js` 등 죽은 코드 각자 담당 영역 정리 후 삭제         |
+
+
+---
+
+## Part 4. 아키텍처 강점 (유지 사항)
+
+- **예약 상태 전이 모델** — `cancel()`/`cancelFully()` 분리, `checkPaid()` Guard 메서드. 의미론적으로 명확
+- **소유권 검증 중앙화** — `SecurityUtils.resolveStaffId()`. ChatController, MedicalController IDOR 방어 완료
+- **SSR/REST 예외 이중 핸들러** — `SsrExceptionHandler` + `GlobalExceptionHandler` 분리. HTTP 상태 코드 정확 반영
+- **PRG 패턴 + Flash Attribute** — 예약/접수 전 흐름 URL 개인정보 노출 없음
+- **비관적 락 + DataIntegrityViolation 이중 방어** — 동시 예약 Race Condition 방어
+- **비활성 직원 세션 자동 강제 로그아웃** — `InactiveStaffLogoutInterceptor` 신규 도입. 퇴사 처리 즉시 세션 만료
+- **퇴사 일정 자동 비활성화** — `StaffRetirementScheduler` @Scheduled(1시간) 도입. 퇴사 일시 도래 시 자동 처리
+- **AdminStaff 테스트 보강** — `AdminStaffServiceTest`, `AdminStaffControllerTest`, `StaffRetirementSchedulerTest`, `InactiveStaffLogoutInterceptorTest` 대폭 업데이트
+- **@Transactional(readOnly=true)** — 클래스 레벨 기본, 쓰기 메서드만 별도. 전체 Service 준수
+- **테스트 패턴** — Given-When-Then + BDDMockito + @DisplayName. 전 테스트 파일 준수
+- **AdminDashboardStatsService 테스트 가능성 개선** — `getDashboardStats(LocalDate)` 오버로딩으로 테스트 가능한 구조 마련
+
+---
+
+## Part 5. 수정 우선순위 일정표
+
+### P0 — 즉시 수정 (CRITICAL 3건)
+
+
+| 담당자 | 작업                                                                   | 예상 노력    |
+| --- | -------------------------------------------------------------------- | -------- |
+| 김민구 | C-01 `tools.jackson` → `com.fasterxml.jackson` import 수정              | 낮음 (30분) |
+| 강상민 | C-02 `admin-rule-form.js` innerHTML → `lucide.createIcons()` API      | 낮음 (30분) |
+| 강상민 | C-03 `AdminStaffService.java:55-68` 깨진 문자열 상수 UTF-8 재저장 + 수정         | 낮음 (1시간) |
+| 조유지 | C-02 `staff-reception-detail.js`, `doctor-treatment-detail.js` innerHTML 제거 | 낮음 (30분) |
+
+
+### P1 — 단기 (HIGH 12건)
+
+
+| 담당자  | 작업                                                                      | 예상 노력           |
+| ---- | ----------------------------------------------------------------------- | --------------- |
+| 김민구  | H-01 다중 Repository 통합                                                    | 높음 (전체 아키텍처 영향) |
+| 강상민  | H-04 `AdminItemController.useItem()` 분리                                  | 낮음 (1시간)        |
+| 조유지  | H-05 ReceptionService 중복 체크 쿼리 교체                                       | 낮음 (30분)        |
+| 조유지  | H-06 ReceptionService N+1 개선                                             | 중간 (2시간)        |
+| 조유지  | H-07 NurseService 히스토리 N+1 개선                                            | 중간 (2시간)        |
+| 강상민/조유지 | H-08 중복 CSS 파일 통합 삭제                                                   | 낮음 (1시간)        |
+| 조유지  | H-09 NurseReceptionController SSR/REST 분리                                | 낮음 (1시간)        |
+| 조유지  | N-H-01 DoctorTreatmentController SSR/REST 분리                             | 낮음 (1시간)        |
+| 조유지  | N-H-02 DoctorTreatmentController GET HttpServletRequest 교체                | 낮음 (30분)        |
+| 조유지  | N-H-03 ReceptionController AJAX → ReceptionApiController 분리              | 중간 (2시간)        |
+| 조유지  | N-H-04 ReceptionController/WalkinController/PhoneReservationController GET Model 교체 | 낮음 (1시간) |
+| 조유지  | N-H-05 ReceptionController.list() 비즈니스 로직 → Service 이전 + Pageable 적용   | 높음 (3시간)        |
+
+
+### P2 — 중기 (MEDIUM 9건)
+
+
+| 담당자 | 작업                                                                                         |
+| --- | ------------------------------------------------------------------------------------------ |
+| 강상민 | C-03 후속 정리, N-M-01 innerHTML → DOM API 교체, M-06 var 제거, N-M-04 에러코드 분기                  |
+| 조유지 | N-M-02 DoctorTreatmentService Clock 주입, M-03 Clock 주입, M-06 var 제거, M-08 미사용 메서드 제거      |
+| 김민구 | M-04 TestSecurityConfig 공통화, M-05 LLM 서비스 테스트, M-07 _sample 정리, N-M-03 인터셉터 캐싱 개선 |

--- a/doc/PBL_FINAL_CHECKLIST_SUBMISSION.md
+++ b/doc/PBL_FINAL_CHECKLIST_SUBMISSION.md
@@ -1,0 +1,260 @@
+# PBL 프로젝트 최종 제출용 점검서
+
+- 작성일: 2026-03-25
+- 프로젝트명: HMS (Hospital Management System)
+- 기준 문서: 사용자 제공 `PBL 프로젝트 최소 요구사항 정의서`
+- 점검 기준: 현재 로컬 프로젝트 코드, 설정 파일, 테스트 실행 결과
+- 최종 판정: 제출 가능 (설명 보완 권장)
+
+---
+
+## 1. 한눈에 보기
+
+| 번호 | 요구사항 | 판정 | 요약 |
+| --- | --- | --- | --- |
+| 1 | REST API + Ajax | 충족 | REST 스타일 JSON API와 `fetch` 기반 비동기 호출 구현 확인 |
+| 2 | DB 테이블 및 연관관계 | 충족 | 도메인 엔티티 15개, `@ManyToOne`, `@OneToOne` 등 JPA 연관관계 다수 확인 |
+| 3 | 인증 및 인가 | 부분 충족 | 로그인과 역할 분리는 구현, 계정 생성은 관리자 직원 등록 방식으로 운영 |
+| 4 | Redis 세션 저장소 | 충족 | `spring-session-data-redis` 적용, 운영 프로필에서 Redis 세션 저장소 활성화 |
+| 5 | Mustache SSR | 충족 | Mustache starter 사용, 템플릿 74개, SSR 컨트롤러 다수 구현 |
+| 6 | 예외처리 및 유효성검증 | 충족 | `@ControllerAdvice`, `@RestControllerAdvice`, `@Valid + BindingResult` 구현 |
+| 7 | 페이징 및 정렬 | 충족 | `Pageable`, `Page<T>`, `PageRequest` 기반 목록 조회 다수 구현 |
+
+---
+
+## 2. 요구사항별 상세 점검
+
+### 2-1. REST API
+
+- 판정: 충족
+- 확인 근거:
+  - `src/main/java/com/smartclinic/hms/reservation/reservation/ReservationApiController.java`
+    - `GET /api/reservation/departments`
+    - `GET /api/reservation/doctors`
+    - `POST /api/reservation/create`
+    - `GET /api/reservation/booked-slots`
+  - `src/main/java/com/smartclinic/hms/admin/dashboard/AdminDashboardApiController.java`
+    - `GET /admin/dashboard/stats`
+    - `GET /admin/dashboard/chart`
+  - `src/main/java/com/smartclinic/hms/admin/staff/AdminStaffApiController.java`
+    - `POST /admin/api/staff/{id}`
+  - `src/main/java/com/smartclinic/hms/admin/patient/AdminPatientApiController.java`
+    - `POST /admin/api/patients/{id}/update`
+- 코드 검색 결과:
+  - `@GetMapping`, `@PostMapping`, `@PutMapping`, `@PatchMapping`, `@DeleteMapping` 어노테이션 총 141건 확인
+- 판단:
+  - 현재 프로젝트는 JSON 응답 기반 API를 충분히 제공하고 있으며, REST API 사용 요구사항을 충족한다.
+  - 일부 관리자 기능은 엄격한 REST 메서드 분리보다 실무형 `POST` 중심으로 구현되어 있으나, 과제 최소 요구사항 충족 여부에는 문제가 없다.
+
+### 2-2. Ajax 호출
+
+- 판정: 충족
+- 확인 근거:
+  - `src/main/resources/static/js/pages/admin-dashboard.js`
+    - `fetch('/admin/dashboard/chart', { method: 'GET' })`
+  - 예약 및 LLM 관련 화면에서도 `fetch` 기반 비동기 호출 구조 사용 확인
+- 판단:
+  - 프론트엔드에서 REST API를 Ajax 방식으로 호출하는 요구사항은 충족한다.
+
+### 2-3. DB 테이블 및 연관관계
+
+- 판정: 충족
+- 확인 근거:
+  - `src/main/java/com/smartclinic/hms/domain` 아래 `@Entity` 기준 도메인 엔티티 15개 확인
+- 대표 엔티티:
+  - `Patient`
+  - `Reservation`
+  - `Staff`
+  - `Doctor`
+  - `Department`
+  - `TreatmentRecord`
+  - `HospitalRule`
+  - `Item`
+- 대표 연관관계:
+  - `src/main/java/com/smartclinic/hms/domain/Reservation.java`
+    - `@ManyToOne Patient`
+    - `@ManyToOne Doctor`
+    - `@ManyToOne Department`
+  - `src/main/java/com/smartclinic/hms/domain/Doctor.java`
+    - `@OneToOne Staff`
+    - `@ManyToOne Department`
+  - `src/main/java/com/smartclinic/hms/domain/TreatmentRecord.java`
+    - `@OneToOne Reservation`
+    - `@ManyToOne Doctor`
+- 판단:
+  - 최소 4개 이상의 엔티티와 JPA 연관관계 요구를 충분히 초과 충족한다.
+
+### 2-4. 인증 및 인가
+
+- 판정: 부분 충족
+- 충족 근거:
+  - `src/main/java/com/smartclinic/hms/auth/AuthController.java`
+    - `GET /login` 로그인 화면 제공
+  - `src/main/java/com/smartclinic/hms/auth/CustomUserDetailsService.java`
+    - `StaffRepository.findByUsernameAndActiveTrue(...)` 기반 사용자 조회
+  - `src/main/java/com/smartclinic/hms/config/SecurityConfig.java`
+    - 역할 기반 접근 제어 구현
+    - `ADMIN`, `DOCTOR`, `NURSE`, `STAFF`, `ITEM_MANAGER` 역할 사용
+  - `src/main/java/com/smartclinic/hms/domain/StaffRole.java`
+    - 5개 역할 정의 확인
+- 애매한 지점:
+  - `/signup`, `/register`, `/join` 같은 공개 회원가입 엔드포인트는 확인되지 않음
+  - 대신 `src/main/java/com/smartclinic/hms/admin/staff/AdminStaffController.java`에서 관리자용 직원 등록(`/admin/staff/create`) 기능이 존재함
+- 판단:
+  - 로그인과 역할 분리 자체는 명확히 구현되어 있다.
+  - 다만 요구사항의 "회원가입"을 공개 자기 등록으로 엄격하게 해석할 경우에는 부분 충족으로 보는 것이 안전하다.
+  - 제출 시에는 "본 시스템은 내부 직원 계정을 관리자 등록 방식으로 생성한다"는 운영 정책 설명을 함께 첨부하는 것이 적절하다.
+
+### 2-5. Redis 세션 저장소
+
+- 판정: 충족
+- 확인 근거:
+  - `build.gradle`
+    - `org.springframework.boot:spring-boot-starter-data-redis` 존재
+    - `org.springframework.session:spring-session-data-redis` 추가 확인
+  - `src/main/resources/application.properties`
+    - `spring.data.redis.repositories.enabled=false`
+    - `spring.config.activate.on-profile=prod`
+    - `spring.session.store-type=redis`
+    - `spring.session.redis.namespace=hms:session`
+    - `server.servlet.session.timeout=30m`
+  - `src/main/resources/application-prod.properties.example`
+    - 운영 예시 설정에도 동일한 Redis 세션 항목 반영
+  - `Dockerfile`
+    - `-Dspring.profiles.active=prod`로 운영 프로필 실행
+  - `src/main/java/com/smartclinic/hms/reservation/reservation/ReservationCompleteInfo.java`
+    - `Serializable` 적용으로 세션/플래시 직렬화 호환성 보완
+- 판단:
+  - 현재 프로젝트는 운영 프로필 기준으로 Spring Session Redis 구성을 완료했다.
+  - 개발 프로필(`dev`)은 H2 기반 로컬 개발 환경을 사용하고, 운영 프로필(`prod`)에서 Redis 세션 저장소를 사용하도록 분리한 구조다.
+  - 따라서 Redis 세션 저장소 요구사항은 충족으로 판단한다.
+
+### 2-6. Mustache SSR
+
+- 판정: 충족
+- 확인 근거:
+  - `build.gradle`
+    - `org.springframework.boot:spring-boot-starter-mustache` 사용
+  - `src/main/resources/templates` 아래 `.mustache` 파일 74개 확인
+  - 대표 SSR 컨트롤러:
+    - `src/main/java/com/smartclinic/hms/auth/AuthController.java`
+      - `return "auth/login"`
+    - `src/main/java/com/smartclinic/hms/reservation/reservation/ReservationController.java`
+      - 예약 화면, 완료 화면, 조회 화면 등 SSR 반환
+- 판단:
+  - Mustache 기반 Server Side Rendering 요구사항은 충분히 충족한다.
+
+### 2-7. 예외처리 및 유효성검증
+
+- 판정: 충족
+- 확인 근거:
+  - 글로벌 예외 처리:
+    - `src/main/java/com/smartclinic/hms/common/exception/GlobalExceptionHandler.java`
+      - `@RestControllerAdvice`
+    - `src/main/java/com/smartclinic/hms/common/exception/SsrExceptionHandler.java`
+      - `@ControllerAdvice`
+  - 서버 사이드 유효성 검증:
+    - `src/main/java/com/smartclinic/hms/admin/department/AdminDepartmentController.java`
+      - `@Valid @ModelAttribute ... BindingResult`
+    - `src/main/java/com/smartclinic/hms/admin/staff/AdminStaffController.java`
+      - `@Valid @ModelAttribute ... BindingResult`
+    - `src/main/java/com/smartclinic/hms/reservation/reservation/ReservationController.java`
+      - `@Valid @ModelAttribute ... BindingResult`
+    - `src/main/java/com/smartclinic/hms/admin/patient/AdminPatientApiController.java`
+      - `@Valid @RequestBody`
+    - `src/main/java/com/smartclinic/hms/reservation/reservation/ReservationApiController.java`
+      - `@Valid @RequestBody`
+- 판단:
+  - 요구사항의 `@ControllerAdvice` 및 `@Valid + BindingResult` 조건은 구현되어 있다.
+
+### 2-8. 페이징 및 정렬
+
+- 판정: 충족
+- 확인 근거:
+  - `src/main/java/com/smartclinic/hms/admin/staff/AdminStaffRepository.java`
+    - `Page<AdminStaffListProjection> findStaffListPage(..., Pageable pageable)`
+  - `src/main/java/com/smartclinic/hms/admin/patient/AdminPatientRepository.java`
+    - `Page<Patient> search(..., Pageable pageable)`
+  - `src/main/java/com/smartclinic/hms/admin/department/AdminDepartmentRepository.java`
+    - `Page<Department> findAllByOrderByIdDesc(Pageable pageable)`
+  - `src/main/java/com/smartclinic/hms/doctor/treatment/DoctorTreatmentService.java`
+    - `Page<DoctorReservationDto>` 반환
+    - `PageRequest.of(...)` 사용
+  - `src/main/java/com/smartclinic/hms/llm/controller/ChatController.java`
+    - `Pageable` 사용
+- 판단:
+  - 목록 조회에 대한 페이징 및 정렬 요구사항은 명확히 충족한다.
+
+---
+
+## 3. 현재 기준 최종 판정
+
+현재 프로젝트는 필수 요구사항 중 다음 항목을 충족한다.
+
+- REST API + Ajax
+- 4개 이상 엔티티 및 JPA 연관관계
+- Redis 세션 저장소
+- Mustache SSR
+- 글로벌 예외처리 및 유효성검증
+- 페이징 및 정렬
+
+인증 및 인가 또한 로그인과 역할 분리 측면에서는 구현이 완료되어 있다.
+다만 계정 생성 방식이 공개 회원가입이 아니라 관리자 직원 등록 방식이므로, 제출 시 이 운영 정책을 설명하는 것이 안전하다.
+
+따라서 현재 HMS 프로젝트의 최종 판정은 다음과 같이 정리할 수 있다.
+
+> 기술 구현 기준으로는 PBL 최소 요구사항을 대부분 충족하며 제출 가능하다.  
+> 단, "회원가입" 항목은 시스템 성격상 관리자 등록 방식으로 운영된다는 설명을 함께 제출하는 것이 바람직하다.
+
+---
+
+## 4. 제출 시 함께 설명하면 좋은 항목
+
+### 4-1. 계정 생성 방식
+
+본 프로젝트는 일반 공개 회원가입 방식이 아니라, 내부 직원 계정을 관리자가 등록하는 방식으로 운영된다.
+
+- 로그인 주체: 내부 직원 (`STAFF`, `DOCTOR`, `NURSE`, `ADMIN`, `ITEM_MANAGER`)
+- 계정 생성 주체: 관리자
+- 관련 기능:
+  - `/login`
+  - `/admin/staff/create`
+
+따라서 인증 및 인가 요구사항은 내부 업무 시스템 관점에서 충족한다고 설명할 수 있다.
+
+### 4-2. 개발 환경과 운영 환경 분리
+
+현재 프로젝트는 개발 환경과 운영 환경을 다음과 같이 분리하여 구성한다.
+
+- 개발 환경(`dev`)
+  - H2 사용
+  - 빠른 로컬 개발 및 테스트 목적
+- 운영 환경(`prod`)
+  - MySQL 사용
+  - Redis 세션 저장소 사용
+
+즉, H2를 사용한다고 해서 Redis 세션 저장소 요구사항이 미충족인 것은 아니며, 운영 프로필에서 Redis 세션이 활성화되는 구조로 구현되어 있다.
+
+### 4-3. 프레임워크 버전
+
+- `build.gradle` 기준 현재 프로젝트는 Spring Boot `4.0.3`, Java `21` 사용
+- 일부 수업 문서가 Spring Boot `3.x`를 기준으로 작성되었을 가능성이 있으므로, 버전 제한이 엄격한지 확인이 필요할 수 있다.
+
+기능 구현 자체와는 별개로, 제출 평가 기준이 특정 버전을 요구하는 경우에는 간단한 설명을 덧붙이는 것이 좋다.
+
+---
+
+## 5. 최종 검증
+
+- 실행 일시: 2026-03-25
+- 실행 명령: `./gradlew clean test`
+- 결과: 성공
+- 비고:
+  - 컴파일, 테스트, 리소스 처리까지 정상 완료
+  - 실행 중 deprecated API 관련 경고는 있었으나 테스트는 정상 통과함
+
+---
+
+## 6. 제출용 한 줄 결론
+
+현재 HMS 프로젝트는 PBL 최소 요구사항을 기술 구현 기준으로 충족하며 제출 가능하고, `회원가입` 항목은 관리자 직원 등록 방식으로 운영된다는 설명을 함께 첨부하는 것이 가장 안전하다.

--- a/docs/superpowers/plans/2026-03-25-hms-code-review-fixes.md
+++ b/docs/superpowers/plans/2026-03-25-hms-code-review-fixes.md
@@ -1,0 +1,1500 @@
+# HMS 코드 리뷰 29건 수정 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `doc/CODE_REVIEW_2026-03-25.md`에 기록된 29건 이슈(CRITICAL 3 / HIGH 12 / MEDIUM 9 / LOW 5)를 리스크 오름차순으로 전부 수정하고 테스트를 통과시킨다.
+
+**Architecture:** 5개 그룹으로 순차 실행 — 비파괴(Group 1) → 구조 분리(Group 2) → 파라미터/로직(Group 3) → 아키텍처(Group 4) → 기타(Group 5). 각 그룹은 독립적으로 컴파일·테스트 가능하도록 설계한다.
+
+**Tech Stack:** Spring Boot 3, Spring MVC (SSR + REST), Spring Security, Spring Data JPA, JUnit 5, Mockito/BDDMockito, @WebMvcTest
+
+---
+
+## File Map (생성/수정 대상 파일)
+
+| 파일 | 작업 | 이슈 |
+|------|------|------|
+| `llm/service/MedicalService.java` | Modify (import 2줄) | C-01 |
+| `admin/staff/AdminStaffService.java` | Modify (lines 55–68 문자열 상수) | C-03 |
+| `static/js/pages/admin-rule-form.js` | Modify (lines 1–10) | C-02 |
+| `static/js/pages/staff-reception-detail.js` | Modify (lines 1–11) | C-02 |
+| `static/js/pages/doctor-treatment-detail.js` | Modify (lines 1–17) | C-02 |
+| `static/js/pages/admin-dashboard.js` | Modify (lines 224–229) | C-02 / N-M-01 |
+| `static/js/pages/admin-rule-form.js` | Modify (var→const) | M-06 |
+| `static/js/pages/admin-staff-form.js` | Modify (var→const) | M-06 |
+| `static/js/pages/staff-reception-detail.js` | Modify (var→const) | M-06 |
+| `static/js/pages/doctor-treatment-detail.js` | Modify (var→const) | M-06 |
+| `_sample/SampleReservation.java` 외 | Modify (@Profile("dev") 추가) | M-07 |
+| `nurse/NurseService.java:86-97` | Modify (메서드 삭제) | M-08 |
+| `static/css/style-admin.css` | Delete (중복 파일) | H-08 |
+| `static/css/style-doctor.css` | Delete (중복 파일) | H-08 |
+| `static/js/data-admin.js`, `data-staff.js`, `data-nurse.js` | Delete (dead code) | L-04 |
+| `admin/reservation/AdminReservationRepository.java` | Modify (nativeQuery → JPQL) | L-05 |
+| `admin/item/AdminItemController.java` | Modify (useItem 제거) | H-04 |
+| `admin/item/AdminItemApiController.java` | **Create** (@RestController) | H-04 |
+| `nurse/NurseReceptionController.java` | Modify (item 엔드포인트 제거) | H-09 |
+| `nurse/NurseItemApiController.java` | **Create** (@RestController) | H-09 |
+| `doctor/treatment/DoctorTreatmentController.java` | Modify (poll/item 엔드포인트 제거, Model→HttpServletRequest) | N-H-01, N-H-02 |
+| `doctor/treatment/DoctorTreatmentApiController.java` | **Create** (@RestController) | N-H-01 |
+| `staff/reception/ReceptionController.java` | Modify (AJAX 엔드포인트 제거, list/detail Model→HttpServletRequest, list 로직 위임) | N-H-03, N-H-04, N-H-05 |
+| `staff/reception/ReceptionApiController.java` | **Create** (@RestController) | N-H-03 |
+| `staff/reception/ReceptionService.java` | Modify (list 로직 흡수, N+1 H-06 수정, H-05 수정) | N-H-05, H-05, H-06 |
+| `staff/reception/dto/ReceptionListResult.java` | **Create** (페이지 결과 DTO Record) | N-H-05 |
+| `staff/walkin/WalkinController.java` | Modify (GET Model→HttpServletRequest) | N-H-04 |
+| `staff/reservation/PhoneReservationController.java` | Modify (GET Model→HttpServletRequest) | N-H-04 |
+| `nurse/NurseService.java` | Modify (N+1 H-07 수정) | H-07 |
+| `doctor/treatment/DoctorTreatmentRecordRepository.java` | Modify (findAllByReservation_IdIn 추가) | H-07 |
+| `admin/staff/AdminStaffController.java` | Modify (message contains → enum 에러 코드) | N-M-04 |
+| `common/exception/StaffErrorCode.java` | **Create** (에러 코드 enum) | N-M-04 |
+| `reservation/reservation/ReservationRepository.java` (및 admin, nurse 중복) | 정식 Repository로 메서드 병합, 중복 Repository 삭제 | H-01 |
+| `nurse/NurseService.java`, `staff/reception/ReceptionService.java` | Modify (Clock 주입) | M-03 |
+| `doctor/treatment/DoctorTreatmentService.java` | Modify (Clock 주입) | N-M-02 |
+| `common/interceptor/InactiveStaffLogoutInterceptor.java` | Modify (세션 캐시) | N-M-03 |
+| `test/common/SharedTestSecurityConfig.java` | **Create** (공통 TestSecurityConfig) | M-04 |
+| 기존 10+ WebMvcTest 클래스 | Modify (내부 중복 제거) | M-04 |
+| `test/llm/LlmReservationServiceTest.java` | Modify (테스트 보강) | M-05 |
+| `test/llm/SymptomAnalysisServiceTest.java` | Modify (테스트 보강) | M-05 |
+| `domain/Doctor.java` 외 | Modify (availableDays 정규화) | L-01 |
+| `common/interceptor/LayoutModelInterceptor.java` | Modify (boolean 플래그 정리) | L-02 |
+| `domain/StaffRole.java` | Modify (getDashboardUrl() 추가) | L-03 |
+
+---
+
+## Group 1: 비파괴 수정 (C-01, C-03, M-06, M-07, M-08, H-08, L-04, L-05)
+
+### Task 1: C-01 — tools.jackson → com.fasterxml.jackson
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/llm/service/MedicalService.java:22-23`
+
+- [ ] **Step 1: import 2줄 수정**
+
+```java
+// 변경 전 (line 22-23)
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+// 변경 후
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+```bash
+cd c:/workspace/gitstudy_lab/demo/team-demo/team-project-demo/hms
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+Expected: BUILD SUCCESS (오류 없음)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/llm/service/MedicalService.java
+git commit -m "fix: C-01 tools.jackson → com.fasterxml.jackson import 수정"
+```
+
+---
+
+### Task 2: C-03 — AdminStaffService 문자열 상수 인코딩 수정
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/admin/staff/AdminStaffService.java:55-68`
+
+- [ ] **Step 1: 깨진 상수 14개를 올바른 문자열로 교체**
+
+line 55~68의 깨진 바이트열 상수를 아래 Unicode 이스케이프 + 의미에 맞는 한글 문자열로 교체한다.
+(line 69 `INACTIVE_STAFF_UPDATE_NOT_ALLOWED_MESSAGE` 형식 참고 — `\uXXXX` 이스케이프 사용)
+
+```java
+private static final String STAFF_CREATED_MESSAGE = "\uC9C1\uC6D0\uC774 \uB4F1\uB85D\uB418\uC5C8\uC2B5\uB2C8\uB2E4.";
+private static final String STAFF_UPDATED_MESSAGE = "\uC9C1\uC6D0 \uC815\uBCF4\uAC00 \uC218\uC815\uB418\uC5C8\uC2B5\uB2C8\uB2E4.";
+private static final String STAFF_DEACTIVATED_MESSAGE = "\uC9C1\uC6D0\uC774 \uBE44\uD65C\uC131\uD654\uB418\uC5C8\uC2B5\uB2C8\uB2E4.";
+private static final String INPUT_CHECK_MESSAGE = "\uC785\uB825\uAC12\uC744 \uD655\uC778\uD574 \uC8FC\uC138\uC694.";
+private static final String INVALID_ROLE_MESSAGE = "\uC720\uD6A8\uD558\uC9C0 \uC54A\uC740 \uC5ED\uD560\uC785\uB2C8\uB2E4.";
+private static final String INVALID_DEPARTMENT_MESSAGE = "\uC720\uD6A8\uD558\uC9C0 \uC54A\uC740 \uBD80\uC11C\uC785\uB2C8\uB2E4.";
+private static final String DUPLICATE_USERNAME_MESSAGE = "\uC774\uBBF8 \uC0AC\uC6A9 \uC911\uC778 \uC544\uC774\uB514\uC785\uB2C8\uB2E4.";
+private static final String DUPLICATE_EMPLOYEE_NUMBER_MESSAGE = "\uC774\uBBF8 \uC0AC\uC6A9 \uC911\uC778 \uC0AC\uBC88\uC785\uB2C8\uB2E4.";
+private static final String STAFF_NOT_FOUND_MESSAGE = "\uC9C1\uC6D0\uC744 \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.";
+private static final String DOCTOR_NOT_FOUND_MESSAGE = "\uC758\uC0AC \uC815\uBCF4\uB97C \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.";
+private static final String PASSWORD_LENGTH_MESSAGE = "\uBE44\uBC00\uBC88\uD638\uB294 8\uC790 \uC774\uC0C1\uC774\uC5B4\uC57C \uD569\uB2C8\uB2E4.";
+private static final String SELF_DEACTIVATE_MESSAGE = "\uC790\uAE30 \uC790\uC2E0\uC740 \uBE44\uD65C\uC131\uD654\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.";
+private static final String ALREADY_DEACTIVATED_MESSAGE = "\uC774\uBBF8 \uBE44\uD65C\uC131\uD654\uB41C \uC9C1\uC6D0\uC785\uB2C8\uB2E4.";
+private static final String REACTIVATION_NOT_ALLOWED_MESSAGE = "\uD574\uB2F9 \uC9C1\uC6D0\uC740 \uC7AC\uD65C\uC131\uD654\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.";
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: 기존 AdminStaffServiceTest 실행**
+
+```bash
+./mvnw test -pl . -Dtest=AdminStaffServiceTest -q 2>&1 | tail -10
+```
+Expected: Tests run: N, Failures: 0, Errors: 0
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/admin/staff/AdminStaffService.java
+git commit -m "fix: C-03 AdminStaffService 깨진 문자열 상수 UTF-8 수정"
+```
+
+---
+
+### Task 3: C-02 / N-M-01 — innerHTML XSS 제거 (4개 JS 파일)
+
+**Files:**
+- Modify: `src/main/resources/static/js/pages/admin-rule-form.js:1-11`
+- Modify: `src/main/resources/static/js/pages/staff-reception-detail.js:1-11`
+- Modify: `src/main/resources/static/js/pages/doctor-treatment-detail.js:1-17`
+- Modify: `src/main/resources/static/js/pages/admin-dashboard.js:224-229`
+
+**방침:** `innerHTML`에 고정 SVG/HTML 리터럴을 할당하는 패턴 → `lucide.createIcons()` API 또는 `createElement` + `setAttribute`/`textContent` 교체.
+
+- [ ] **Step 1: admin-rule-form.js — lucide API 교체**
+
+`container.innerHTML = '<i data-lucide="...">`를 다음 패턴으로 교체:
+
+```js
+function toggleActiveIcon() {
+  const isActive = document.getElementById('ruleIsActive').checked;
+  const container = document.getElementById('activeIconContainer');
+  // 기존 아이콘 제거 후 새 아이콘 생성
+  container.replaceChildren();
+  const icon = document.createElement('i');
+  icon.setAttribute('data-lucide', isActive ? 'check-circle-2' : 'x-circle');
+  icon.className = isActive ? 'w-5 h-5 text-green-500' : 'w-5 h-5 text-slate-400';
+  container.appendChild(icon);
+  lucide.createIcons();
+}
+```
+
+- [ ] **Step 2: staff-reception-detail.js — 스피너를 createElement 로 교체**
+
+line 3의 `btn.innerHTML = '<div class="...">...</div> ...'`를:
+
+```js
+function handleReceive(event) {
+  const btn = event.currentTarget;
+  // 스피너 생성
+  const spinner = document.createElement('div');
+  spinner.className = 'w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin';
+  const label = document.createTextNode(' 접수 완료 처리 (RECEIVED)');
+  btn.replaceChildren(spinner, label);
+  btn.disabled = true;
+  btn.classList.add('opacity-50');
+  // 이하 동일
+```
+
+- [ ] **Step 3: doctor-treatment-detail.js — 스피너를 createElement 로 교체**
+
+line 9의 `btn.innerHTML = '<div ...>...</div> 진료 완료'`를:
+
+```js
+  const spinner = document.createElement('div');
+  spinner.className = 'w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin';
+  const label = document.createTextNode(' 진료 완료');
+  btn.replaceChildren(spinner, label);
+```
+
+- [ ] **Step 4: admin-dashboard.js — innerHTML 빈 상태 렌더링 교체**
+
+line 225: `container.innerHTML = renderItemFlowEmptyState();` →
+`renderItemFlowEmptyState()`가 순수 정적 문자열(서버 데이터 미포함)인지 확인.
+서버 데이터를 삽입하지 않는 정적 HTML이므로 `DOMParser` + `appendChild` 패턴으로 교체:
+
+```js
+if (!Array.isArray(itemFlowDays) || itemFlowDays.length === 0) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(renderItemFlowEmptyState(), 'text/html');
+  container.replaceChildren(...doc.body.childNodes);
+  return;
+}
+// line 229 — template literal 차트 HTML 교체 (동일 패턴)
+const chartHtml = `<div ...>...</div>`;
+const parser = new DOMParser();
+const doc = parser.parseFromString(chartHtml, 'text/html');
+container.replaceChildren(...doc.body.childNodes);
+```
+
+> **주의:** `renderItemFlowColumn(item)` 함수가 외부 서버 데이터를 `textContent` 없이 문자열에 삽입하는 경우 별도 XSS 검토 필요. 현재 `item` 필드는 숫자형(count, date)으로 가정.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/resources/static/js/pages/admin-rule-form.js \
+        src/main/resources/static/js/pages/staff-reception-detail.js \
+        src/main/resources/static/js/pages/doctor-treatment-detail.js \
+        src/main/resources/static/js/pages/admin-dashboard.js
+git commit -m "fix: C-02/N-M-01 innerHTML XSS 제거 — createElement + lucide API 교체"
+```
+
+---
+
+### Task 4: M-06 — var → const/let (JS 파일 전체)
+
+**Files:**
+- Modify: `src/main/resources/static/js/pages/admin-rule-form.js`
+- Modify: `src/main/resources/static/js/pages/admin-staff-form.js`
+- Modify: `src/main/resources/static/js/pages/staff-reception-detail.js`
+- Modify: `src/main/resources/static/js/pages/doctor-treatment-detail.js`
+
+**규칙:** 재할당 없는 변수 → `const`, 재할당 있는 변수 → `let`. `var` 전부 제거.
+
+- [ ] **Step 1: 각 파일 var → const/let 전환**
+
+각 파일을 열어 `var` 선언을 `const` 또는 `let`으로 교체한다.
+- 루프 카운터(`i`, `j`) → `let`
+- 재할당(`=`)이 없는 변수 → `const`
+- `if` 블록 내 조건에 따라 재할당되는 경우 → `let`
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/main/resources/static/js/pages/admin-rule-form.js \
+        src/main/resources/static/js/pages/admin-staff-form.js \
+        src/main/resources/static/js/pages/staff-reception-detail.js \
+        src/main/resources/static/js/pages/doctor-treatment-detail.js
+git commit -m "fix: M-06 var → const/let 전환 (JS 파일)"
+```
+
+---
+
+### Task 5: M-07 — _sample 패키지 @Profile("dev") 추가
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/_sample/SampleReservation.java`
+- Modify: `src/main/java/com/smartclinic/hms/_sample/SampleBusinessException.java`
+- Modify: `src/main/java/com/smartclinic/hms/_sample/dto/SampleReservationCreateRequest.java`
+- Modify: `src/main/java/com/smartclinic/hms/_sample/dto/SampleReservationResponse.java`
+
+`SampleReservation` 엔티티는 `@Entity` + `@Table`을 가지고 있어 DDL이 운영 환경에서 실행된다.
+`@Profile("dev")`를 `@Entity` 클래스에 추가하거나, 해당 클래스를 `src/test/java`로 이동한다.
+
+- [ ] **Step 1: SampleReservation에 @Profile 추가 (또는 test 소스셋으로 이동 확인)**
+
+`@Entity` 클래스에 `@Profile("dev")`를 추가하는 방식 선택:
+
+```java
+import org.springframework.context.annotation.Profile;
+
+@Profile("dev")
+@Entity
+@Table(name = "sample_reservations")
+public class SampleReservation { ... }
+```
+
+> 테스트 소스셋으로 이동하는 경우 `@Entity` 스캔 범위를 확인해야 하므로 `@Profile("dev")` 방식을 권장.
+
+- [ ] **Step 2: 컴파일 + 테스트**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/_sample/
+git commit -m "fix: M-07 _sample 패키지 @Profile(dev) 추가"
+```
+
+---
+
+### Task 6: M-08 — NurseService.toKoreanDayOfWeek() 미사용 메서드 제거
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/nurse/NurseService.java:86-97`
+
+- [ ] **Step 1: private 메서드 toKoreanDayOfWeek(int) 삭제**
+
+lines 83–97 (Javadoc 포함) 전체 제거.
+
+- [ ] **Step 2: 컴파일 확인**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/nurse/NurseService.java
+git commit -m "fix: M-08 NurseService 미사용 toKoreanDayOfWeek() 제거"
+```
+
+---
+
+### Task 7: H-08 — 중복 CSS 파일 삭제
+
+**Files:**
+- Delete: `src/main/resources/static/css/style-admin.css` (admin-style.css와 동일)
+- Delete: `src/main/resources/static/css/style-doctor.css` (doctor-style.css와 동일)
+
+- [ ] **Step 1: 두 CSS 파일이 실제로 동일한지 확인**
+
+```bash
+diff src/main/resources/static/css/admin-style.css src/main/resources/static/css/style-admin.css
+diff src/main/resources/static/css/doctor-style.css src/main/resources/static/css/style-doctor.css
+```
+Expected: 두 diff 모두 출력 없음 (파일 내용 동일)
+
+- [ ] **Step 2: Mustache 템플릿에서 style-admin.css / style-doctor.css 참조 검색**
+
+```bash
+grep -r "style-admin\|style-doctor" src/main/resources/templates/
+```
+만약 참조가 있으면 해당 템플릿의 `<link>` 경로를 `admin-style.css` / `doctor-style.css`로 교체.
+참조가 없으면 바로 삭제.
+
+- [ ] **Step 3: 파일 삭제**
+
+```bash
+git rm src/main/resources/static/css/style-admin.css
+git rm src/main/resources/static/css/style-doctor.css
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "fix: H-08 중복 CSS 파일(style-admin/doctor) 삭제"
+```
+
+---
+
+### Task 8: L-04 / L-05 — 죽은 JS 파일 삭제 + nativeQuery → JPQL
+
+**Files:**
+- Delete: `src/main/resources/static/js/data-admin.js`
+- Delete: `src/main/resources/static/js/data-staff.js`
+- Delete: `src/main/resources/static/js/data-nurse.js`
+- Modify: `src/main/java/com/smartclinic/hms/admin/reservation/AdminReservationRepository.java`
+
+- [ ] **Step 1: JS 파일 참조 검색**
+
+```bash
+grep -r "data-admin\.js\|data-staff\.js\|data-nurse\.js" src/main/resources/templates/
+```
+참조가 있으면 해당 `<script>` 태그 제거 후 삭제. 없으면 바로 삭제.
+
+- [ ] **Step 2: JS 파일 삭제**
+
+```bash
+git rm src/main/resources/static/js/data-admin.js \
+       src/main/resources/static/js/data-staff.js \
+       src/main/resources/static/js/data-nurse.js 2>/dev/null || true
+```
+
+- [ ] **Step 3: AdminReservationRepository nativeQuery → JPQL**
+
+`AdminReservationRepository.java`의 `nativeQuery = true` 쿼리를 JPQL로 전환한다.
+(`@Query("SELECT r FROM Reservation r ...")` 방식, Spring Data 파생 메서드로 표현 가능한 경우 파생 메서드 우선)
+
+- [ ] **Step 4: 컴파일 + AdminReservationServiceTest 실행**
+
+```bash
+./mvnw test -pl . -Dtest=AdminReservationServiceTest -q 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "fix: L-04 죽은 JS 파일 삭제, L-05 AdminReservationRepository nativeQuery → JPQL"
+```
+
+---
+
+## Group 2: 구조 분리 — SSR/REST 혼재 컨트롤러 분리 (H-04, H-09, N-H-01, N-H-03, C-02 추가 대응)
+
+**원칙:** `@Controller` 클래스에서 `@ResponseBody` 엔드포인트를 추출해 새 `@RestController`로 이동. 기존 URL 유지. `Resp.ok()` 사용.
+
+---
+
+### Task 9: H-04 — AdminItemController → AdminItemApiController 분리
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/admin/item/AdminItemController.java` (useItem 제거)
+- Create: `src/main/java/com/smartclinic/hms/admin/item/AdminItemApiController.java`
+
+- [ ] **Step 1: AdminItemApiController 생성**
+
+```java
+package com.smartclinic.hms.admin.item;
+
+import com.smartclinic.hms.common.util.Resp;
+import com.smartclinic.hms.item.ItemManagerService;
+import com.smartclinic.hms.item.log.ItemUsageLogDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/item")
+public class AdminItemApiController {
+
+    private final ItemManagerService itemManagerService;
+
+    @PostMapping("/use")
+    public ResponseEntity<Resp<Map<String, Object>>> useItem(
+            @RequestParam("id") Long id,
+            @RequestParam("amount") String amountStr) {
+        long parsed = Long.parseLong(amountStr.trim());
+        if (parsed <= 0 || parsed > Integer.MAX_VALUE) {
+            return Resp.fail(org.springframework.http.HttpStatus.BAD_REQUEST, "INVALID_AMOUNT", "올바른 수량을 입력해 주세요.");
+        }
+        int newQuantity = itemManagerService.useItem(id, (int) parsed, null);
+        List<ItemUsageLogDto> logs = itemManagerService.getTodayStaffUsageLogs();
+        long totalUsedAmount = itemManagerService.getTodayTotalStaffUsageAmount();
+        Map<String, Object> body = Map.of(
+                "quantity", newQuantity,
+                "logs", logs,
+                "todayLogCount", logs.size(),
+                "todayTotalUsedAmount", totalUsedAmount);
+        return Resp.ok(body);
+    }
+}
+```
+
+> 예외 처리는 `GlobalExceptionHandler`가 담당하므로 try-catch 불필요.
+
+- [ ] **Step 2: AdminItemController에서 useItem 메서드 제거**
+
+`AdminItemController.java:108-131`의 `@PostMapping("/use") @ResponseBody public ResponseEntity<?> useItem(...)` 메서드 삭제.
+관련 import (`ResponseBody`, `ResponseEntity`, `Map`) 중 더 이상 사용되지 않는 것 제거.
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 4: AdminItemControllerTest + AdminItemServiceTest 실행**
+
+```bash
+./mvnw test -pl . -Dtest="AdminItemControllerTest,AdminItemServiceTest" -q 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/admin/item/
+git commit -m "fix: H-04 AdminItemController useItem → AdminItemApiController(@RestController) 분리"
+```
+
+---
+
+### Task 10: H-09 — NurseReceptionController → NurseItemApiController 분리
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/nurse/NurseReceptionController.java` (lines 382-415 제거)
+- Create: `src/main/java/com/smartclinic/hms/nurse/NurseItemApiController.java`
+
+- [ ] **Step 1: NurseItemApiController 생성**
+
+```java
+package com.smartclinic.hms.nurse;
+
+import com.smartclinic.hms.common.util.Resp;
+import com.smartclinic.hms.item.ItemManagerService;
+import com.smartclinic.hms.item.log.ItemUsageLogDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/nurse")
+public class NurseItemApiController {
+
+    private final ItemManagerService itemManagerService;
+
+    @PostMapping("/item/use")
+    public ResponseEntity<Resp<Map<String, Object>>> useItem(
+            @RequestParam("id") Long id,
+            @RequestParam("amount") String amountStr,
+            @RequestParam(name = "reservationId", required = false) Long reservationId) {
+        long parsed = Long.parseLong(amountStr.trim());
+        if (parsed <= 0 || parsed > Integer.MAX_VALUE) {
+            return Resp.fail(org.springframework.http.HttpStatus.BAD_REQUEST, "INVALID_AMOUNT", "올바른 수량을 입력해주세요.");
+        }
+        int newQuantity = itemManagerService.useItem(id, (int) parsed, reservationId);
+        List<ItemUsageLogDto> logs = reservationId != null
+                ? itemManagerService.getUsageLogs(reservationId)
+                : List.of();
+        return Resp.ok(Map.of("quantity", newQuantity, "logs", logs));
+    }
+
+    @PostMapping("/item/cancel")
+    public ResponseEntity<Resp<Map<String, Object>>> cancelUsage(
+            @RequestParam("logId") Long logId,
+            @RequestParam("reservationId") Long reservationId) {
+        itemManagerService.cancelItemUsage(logId);
+        List<ItemUsageLogDto> logs = itemManagerService.getUsageLogs(reservationId);
+        return Resp.ok(Map.of("success", true, "logs", logs));
+    }
+}
+```
+
+- [ ] **Step 2: NurseReceptionController에서 item 엔드포인트 제거**
+
+`NurseReceptionController.java:382-415` (`useItem`, `cancelUsage` 메서드) 삭제.
+더 이상 필요 없는 import 정리 (`ResponseBody`, `ItemManagerService`, `ItemUsageLogDto` 등).
+
+- [ ] **Step 3: 컴파일 + 테스트**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/nurse/
+git commit -m "fix: H-09 NurseReceptionController item 엔드포인트 → NurseItemApiController 분리"
+```
+
+---
+
+### Task 11: N-H-01 — DoctorTreatmentController → DoctorTreatmentApiController 분리
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/doctor/treatment/DoctorTreatmentController.java` (poll/item 엔드포인트 제거)
+- Create: `src/main/java/com/smartclinic/hms/doctor/treatment/DoctorTreatmentApiController.java`
+
+- [ ] **Step 1: DoctorTreatmentApiController 생성**
+
+poll 엔드포인트(line 36-42)와 item 엔드포인트(lines 101-138) 이동.
+기존 `ResponseEntity<?>` + `Map.of()` 반환을 `Resp.ok()` 방식으로 통일.
+
+```java
+package com.smartclinic.hms.doctor.treatment;
+
+import com.smartclinic.hms.common.util.Resp;
+import com.smartclinic.hms.item.ItemManagerService;
+import com.smartclinic.hms.item.log.ItemUsageLogDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/doctor")
+public class DoctorTreatmentApiController {
+
+    private final DoctorTreatmentService treatmentService;
+    private final ItemManagerService itemManagerService;
+
+    @GetMapping("/treatment-list/poll")
+    public ResponseEntity<Resp<List<DoctorReservationDto>>> pollTreatmentList(
+            Authentication auth,
+            @RequestParam(name = "query", required = false) String query) {
+        List<DoctorReservationDto> list = treatmentService.getTodayReceivedList(auth.getName(), query);
+        return Resp.ok(list);
+    }
+
+    @PostMapping("/item/use")
+    public ResponseEntity<Resp<Map<String, Object>>> useItem(
+            @RequestParam("id") Long id,
+            @RequestParam("amount") String amountStr,
+            @RequestParam(name = "reservationId", required = false) Long reservationId) {
+        long parsed = Long.parseLong(amountStr.trim());
+        if (parsed <= 0 || parsed > Integer.MAX_VALUE) {
+            return Resp.fail(org.springframework.http.HttpStatus.BAD_REQUEST, "INVALID_AMOUNT", "올바른 수량을 입력해주세요.");
+        }
+        int newQuantity = itemManagerService.useItem(id, (int) parsed, reservationId);
+        List<ItemUsageLogDto> logs = reservationId != null
+                ? itemManagerService.getUsageLogs(reservationId)
+                : List.of();
+        return Resp.ok(Map.of("quantity", newQuantity, "logs", logs));
+    }
+
+    @PostMapping("/item/cancel")
+    public ResponseEntity<Resp<Map<String, Object>>> cancelItem(
+            @RequestParam("logId") Long logId,
+            @RequestParam("reservationId") Long reservationId) {
+        Map<String, Object> result = itemManagerService.cancelItemUsage(logId);
+        List<ItemUsageLogDto> logs = itemManagerService.getUsageLogs(reservationId);
+        return Resp.ok(Map.of(
+                "itemId", result.get("itemId"),
+                "quantity", result.get("quantity"),
+                "logs", logs));
+    }
+}
+```
+
+- [ ] **Step 2: DoctorTreatmentController에서 poll/item 엔드포인트 제거**
+
+lines 35-42 (poll), lines 101-138 (useItem, cancelItem) 삭제.
+관련 import 정리.
+
+- [ ] **Step 3: 컴파일 + 테스트**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/doctor/treatment/
+git commit -m "fix: N-H-01 DoctorTreatmentController REST 엔드포인트 → DoctorTreatmentApiController 분리"
+```
+
+---
+
+### Task 12: N-H-03 — ReceptionController AJAX → ReceptionApiController 분리
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/staff/reception/ReceptionController.java` (lines 273-337 제거)
+- Create: `src/main/java/com/smartclinic/hms/staff/reception/ReceptionApiController.java`
+
+- [ ] **Step 1: ReceptionApiController 생성**
+
+`receiveAjax`, `cancelAjax`, `payAjax`, `updatePatientInfo` 4개 엔드포인트를 새 `@RestController`로 이동.
+`Map<String,Object>` 반환을 `Resp.ok()` 방식으로 통일.
+
+```java
+package com.smartclinic.hms.staff.reception;
+
+import com.smartclinic.hms.common.util.Resp;
+import com.smartclinic.hms.domain.Reservation;
+import com.smartclinic.hms.domain.ReservationStatus;
+import com.smartclinic.hms.staff.reception.dto.PatientInfoUpdateRequest;
+import com.smartclinic.hms.staff.reception.dto.ReceptionUpdateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/staff/reception")
+public class ReceptionApiController {
+
+    private final ReceptionService receptionService;
+
+    @PostMapping("/receive-ajax")
+    public ResponseEntity<Resp<Map<String, Object>>> receiveAjax(@RequestBody ReceptionUpdateRequest request) {
+        receptionService.receive(request);
+        return Resp.ok(Map.of(
+                "success", true,
+                "statusText", "진료 대기",
+                "statusClass", "bg-orange-100 text-orange-700"));
+    }
+
+    @PostMapping("/cancel-ajax")
+    public ResponseEntity<Resp<Map<String, Object>>> cancelAjax(@RequestBody Map<String, Object> request) {
+        Long id = Long.valueOf(request.get("id").toString());
+        String reason = (String) request.getOrDefault("reason", "");
+        Reservation r = receptionService.cancel(id, reason);
+        String statusText = r.getStatus() == ReservationStatus.CANCELLED ? "취소" : "예약";
+        String statusClass = r.getStatus() == ReservationStatus.CANCELLED
+                ? "bg-red-100 text-red-700"
+                : "bg-blue-100 text-blue-700";
+        return Resp.ok(Map.of(
+                "success", true,
+                "newStatus", r.getStatus().name(),
+                "statusText", statusText,
+                "statusClass", statusClass));
+    }
+
+    @PostMapping("/pay-ajax")
+    public ResponseEntity<Resp<Map<String, Object>>> payAjax(@RequestBody Map<String, Object> request) {
+        Long id = Long.valueOf(request.get("id").toString());
+        receptionService.completePayment(id);
+        return Resp.ok(Map.of("success", true, "message", "수납이 완료되었습니다."));
+    }
+
+    @PostMapping("/update-patient-info")
+    public ResponseEntity<Resp<Map<String, Object>>> updatePatientInfo(
+            @RequestBody @Valid PatientInfoUpdateRequest request) {
+        receptionService.updatePatientInfo(request);
+        return Resp.ok(Map.of("success", true, "message", "환자 정보가 수정되었습니다."));
+    }
+}
+```
+
+- [ ] **Step 2: ReceptionController에서 4개 AJAX 엔드포인트 제거 (lines 273-337)**
+
+관련 import 정리 (`ResponseBody`, `RequestBody`, `Map`, `HashMap` 등).
+
+- [ ] **Step 3: 컴파일 + 테스트**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/staff/reception/
+git commit -m "fix: N-H-03 ReceptionController AJAX 엔드포인트 → ReceptionApiController 분리 + Resp.ok()"
+```
+
+---
+
+## Group 3: 파라미터/로직 수정 (N-H-02, N-H-04, N-H-05, H-05, H-06, H-07, N-M-04)
+
+---
+
+### Task 13: N-H-02 + N-H-04 — GET SSR 핸들러 Model → HttpServletRequest
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/doctor/treatment/DoctorTreatmentController.java`
+- Modify: `src/main/java/com/smartclinic/hms/staff/reception/ReceptionController.java` (list, detail)
+- Modify: `src/main/java/com/smartclinic/hms/staff/walkin/WalkinController.java`
+- Modify: `src/main/java/com/smartclinic/hms/staff/reservation/PhoneReservationController.java`
+
+**패턴:**
+```java
+// 변경 전
+public String someView(Model model) {
+    model.addAttribute("key", value);
+    return "view-name";
+}
+
+// 변경 후
+public String someView(HttpServletRequest request) {
+    request.setAttribute("key", value);
+    return "view-name";
+}
+```
+
+- [ ] **Step 1: DoctorTreatmentController GET 핸들러 수정**
+
+`treatmentList()`, `treatmentDetail()`, `completedDetail()` 세 핸들러의 `Model model` → `HttpServletRequest request` 교체.
+`model.addAttribute(k, v)` → `request.setAttribute(k, v)`.
+import: `org.springframework.ui.Model` 제거, `jakarta.servlet.http.HttpServletRequest` 추가.
+
+- [ ] **Step 2: ReceptionController list() + detail() GET 핸들러 수정**
+
+`list()` (line 41)와 `detail()` (line 224)의 `Model model` → `HttpServletRequest request`.
+`model.addAttribute(k, v)` → `request.setAttribute(k, v)`.
+
+> N-H-05 작업(list 로직 위임)과 연계됨. 이 단계에서는 시그니처만 교체하고 로직은 다음 Task에서 처리.
+
+- [ ] **Step 3: WalkinController walkinPage() 수정**
+
+`walkinPage()` (line 33)의 `Model model` → `HttpServletRequest request`.
+
+- [ ] **Step 4: PhoneReservationController phoneReservation() 수정**
+
+`phoneReservation()` (line 31)의 `Model model` → `HttpServletRequest request`.
+(POST 핸들러 `createPhoneReservation()`은 PRG 패턴이므로 `Model model` 유지)
+
+- [ ] **Step 5: 컴파일 확인**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/doctor/treatment/DoctorTreatmentController.java \
+        src/main/java/com/smartclinic/hms/staff/reception/ReceptionController.java \
+        src/main/java/com/smartclinic/hms/staff/walkin/WalkinController.java \
+        src/main/java/com/smartclinic/hms/staff/reservation/PhoneReservationController.java
+git commit -m "fix: N-H-02/N-H-04 GET SSR 핸들러 Model → HttpServletRequest 교체"
+```
+
+---
+
+### Task 14: N-H-05 + H-05 + H-06 — ReceptionService 로직 위임 + N+1 수정
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/staff/reception/ReceptionService.java`
+- Modify: `src/main/java/com/smartclinic/hms/staff/reception/ReceptionController.java` (list 로직 제거)
+- Create: `src/main/java/com/smartclinic/hms/staff/reception/dto/ReceptionListResult.java`
+- Modify: `src/main/java/com/smartclinic/hms/reservation/reservation/ReservationRepository.java` (배치 쿼리 추가)
+
+**N-H-05:** `ReceptionController.list()`의 200줄 로직(탭 필터, 수동 페이징, 파라미터 빌더)을 Service로 위임.
+**H-05:** `createPhoneReservation()`의 전체 예약 로드 → `existsByDoctor_IdAndReservationDateAndTimeSlotAndStatusNot()` 단일 쿼리.
+**H-06:** `getReservations()` 스트림 내 `countByPatient_IdAndStatus()` N+1 → `countCompletedByPatientIds()` 배치 쿼리.
+
+- [ ] **Step 1: ReceptionListResult Record 생성**
+
+```java
+package com.smartclinic.hms.staff.reception.dto;
+
+import com.smartclinic.hms.staff.dto.StaffReservationDto;
+import java.util.List;
+import java.util.Map;
+
+public record ReceptionListResult(
+    List<StaffReservationDto> reservations,
+    int currentPage,
+    int totalPages,
+    int totalCount,
+    boolean hasPrev,
+    boolean hasNext,
+    int prevPage,
+    int nextPage,
+    List<Map<String, Object>> pageLinks
+) {}
+```
+
+- [ ] **Step 2: ReservationRepository에 배치 쿼리 추가 (H-06)**
+
+```java
+// 환자 ID 목록에 대한 COMPLETED 건수를 한 번에 조회 (N+1 방지)
+@Query("SELECT r.patient.id, COUNT(r) FROM Reservation r " +
+       "WHERE r.patient.id IN :patientIds AND r.status = :status " +
+       "GROUP BY r.patient.id")
+List<Object[]> countCompletedByPatientIds(
+    @Param("patientIds") List<Long> patientIds,
+    @Param("status") ReservationStatus status);
+```
+
+- [ ] **Step 3: H-05 수정 — createPhoneReservation() 중복 체크**
+
+`ReceptionService.java:92-98`의 전체 예약 로드 + 스트림 필터를 단일 쿼리로 교체:
+
+```java
+// 변경 전 (lines 92-98)
+List<Reservation> existingReservations = reservationRepository.findTodayExcludingStatus(reservationDate, ReservationStatus.CANCELLED);
+boolean isDuplicate = existingReservations.stream()
+    .anyMatch(r -> r.getDoctor().getId().equals(doctor.getId()) && r.getTimeSlot().equals(request.getTime()));
+
+// 변경 후
+boolean isDuplicate = reservationRepository.existsByDoctor_IdAndReservationDateAndTimeSlotAndStatusNot(
+    doctor.getId(), reservationDate, request.getTime(), ReservationStatus.CANCELLED);
+```
+
+- [ ] **Step 4: H-06 수정 — getReservations() N+1 제거**
+
+`ReceptionService.java:216-221` 수정:
+
+```java
+// 변경 전 (스트림 내 N+1)
+.map(r -> {
+    long completedCount = reservationRepository.countByPatient_IdAndStatus(r.getPatient().getId(), ReservationStatus.COMPLETED);
+    return new StaffReservationDto(r, completedCount);
+})
+
+// 변경 후 — 배치 조회 후 Map으로 활용
+List<Long> patientIds = reservations.stream().map(r -> r.getPatient().getId()).distinct().collect(Collectors.toList());
+Map<Long, Long> completedCountMap = reservationRepository
+    .countCompletedByPatientIds(patientIds, ReservationStatus.COMPLETED)
+    .stream()
+    .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+
+return reservations.stream()
+    .filter(/* 기존 필터 동일 */)
+    .map(r -> {
+        long completedCount = completedCountMap.getOrDefault(r.getPatient().getId(), 0L);
+        return new StaffReservationDto(r, completedCount);
+    })
+    .collect(Collectors.toList());
+```
+
+- [ ] **Step 5: N-H-05 수정 — list() 로직 Service로 위임**
+
+`ReceptionService`에 다음 시그니처의 메서드 추가:
+
+```java
+public ReceptionListResult getReceptionListResult(
+        LocalDate date, String tab, String query,
+        List<Long> deptIds, List<Long> doctorIds, String source, int page) {
+    // 1. dbStatus 매핑 (tab → RESERVED/RECEIVED/CANCELLED/null)
+    // 2. getReservations() 호출
+    // 3. treatment_status / paid 탭 정밀 필터링 + statusText 변환
+    // 4. rowNum 부여
+    // 5. 페이징 (pageSize=10, subList 기반 → 이미 Service에 있으므로 이동)
+    // 6. pageLinks 목록 생성
+    // 7. ReceptionListResult record 반환
+}
+```
+
+`ReceptionController.list()`는 이 메서드를 호출한 뒤 `request.setAttribute`로만 구성:
+
+```java
+@GetMapping("/list")
+public String list(HttpServletRequest request, /* @RequestParam들 */) {
+    ReceptionListResult result = receptionService.getReceptionListResult(
+        selectedDate, currentTab, query, deptIds, doctorIds, source, page);
+    request.setAttribute("reservations", result.reservations());
+    request.setAttribute("currentPage", result.currentPage());
+    // ... result 필드를 setAttribute로 전달
+    return "staff/reception-list";
+}
+```
+
+- [ ] **Step 6: 컴파일 + 테스트**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/staff/reception/ \
+        src/main/java/com/smartclinic/hms/reservation/reservation/ReservationRepository.java
+git commit -m "fix: N-H-05/H-05/H-06 ReceptionService 로직 위임 + N+1 제거 + 중복 체크 단일 쿼리"
+```
+
+---
+
+### Task 15: H-07 — NurseService.getPatientDetail() N+1 수정
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/nurse/NurseService.java:205-224`
+- Modify: `src/main/java/com/smartclinic/hms/doctor/treatment/DoctorTreatmentRecordRepository.java`
+
+- [ ] **Step 1: DoctorTreatmentRecordRepository에 배치 조회 메서드 추가**
+
+```java
+List<TreatmentRecord> findAllByReservation_IdIn(List<Long> reservationIds);
+```
+
+- [ ] **Step 2: NurseService.getPatientDetail() N+1 수정**
+
+lines 208-224의 루프 내 `treatmentRecordRepository.findByReservation_Id(h.getId())` 호출을 배치로 교체:
+
+```java
+// 변경 전 — 루프마다 DB 쿼리
+.map(h -> {
+    TreatmentRecord tr = treatmentRecordRepository.findByReservation_Id(h.getId()).orElse(null);
+    ...
+})
+
+// 변경 후 — 배치 조회 후 Map 활용
+List<Long> historyIds = histories.stream()
+    .filter(h -> !h.getId().equals(reservationId) && h.getStatus() == ReservationStatus.COMPLETED)
+    .map(Reservation::getId)
+    .collect(Collectors.toList());
+
+Map<Long, TreatmentRecord> trMap = treatmentRecordRepository
+    .findAllByReservation_IdIn(historyIds)
+    .stream()
+    .collect(Collectors.toMap(tr -> tr.getReservation().getId(), tr -> tr));
+
+List<NursePatientDto.NurseTreatmentHistoryDto> historyDtos = histories.stream()
+    .filter(h -> !h.getId().equals(reservationId) && h.getStatus() == ReservationStatus.COMPLETED)
+    .map(h -> {
+        TreatmentRecord tr = trMap.get(h.getId());
+        return new NursePatientDto.NurseTreatmentHistoryDto(...);
+    })
+    .toList();
+```
+
+- [ ] **Step 3: 컴파일 + 테스트**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/nurse/NurseService.java \
+        src/main/java/com/smartclinic/hms/doctor/treatment/DoctorTreatmentRecordRepository.java
+git commit -m "fix: H-07 NurseService.getPatientDetail() N+1 → findAllByReservation_IdIn 배치 조회"
+```
+
+---
+
+### Task 16: N-M-04 — AdminStaffController 에러 라우팅 → enum 에러 코드 기반
+
+**Files:**
+- Create: `src/main/java/com/smartclinic/hms/admin/staff/StaffErrorCode.java`
+- Modify: `src/main/java/com/smartclinic/hms/admin/staff/AdminStaffController.java:138-183`
+- Modify: `src/main/java/com/smartclinic/hms/admin/staff/AdminStaffService.java` (예외 throw 시 에러 코드 포함)
+
+- [ ] **Step 1: StaffErrorCode enum 생성**
+
+```java
+package com.smartclinic.hms.admin.staff;
+
+public enum StaffErrorCode {
+    INVALID_DEPARTMENT,
+    INVALID_ROLE,
+    DUPLICATE_USERNAME,
+    DUPLICATE_EMPLOYEE_NUMBER,
+    STAFF_NOT_FOUND,
+    DOCTOR_NOT_FOUND,
+    PASSWORD_TOO_SHORT,
+    SELF_DEACTIVATE,
+    ALREADY_DEACTIVATED,
+    REACTIVATION_NOT_ALLOWED,
+    INACTIVE_STAFF_UPDATE
+}
+```
+
+- [ ] **Step 2: AdminStaffService에서 CustomException throw 시 에러 코드 사용**
+
+`CustomException`은 이미 `String errorCode` 필드와 `badRequest(String errorCode, String message)` 팩토리 메서드를 갖추고 있다(`common/exception/CustomException.java:54, 82`). 별도 수정 불필요.
+
+```java
+// 변경 전 (errorCode 없이 throw하는 경우)
+throw CustomException.badRequest("VALIDATION_ERROR", "부서 정보를 찾을 수 없습니다.");
+
+// 변경 후 (StaffErrorCode enum 사용)
+throw CustomException.badRequest(StaffErrorCode.INVALID_DEPARTMENT.name(), "부서 정보를 찾을 수 없습니다.");
+```
+
+- [ ] **Step 3: AdminStaffController.applyCreateViewErrors() 수정**
+
+```java
+// 변경 전 — 문자열 포함 여부로 분기
+if (e.getMessage().contains("부서")) { ... }
+
+// 변경 후 — 에러 코드 기반 분기
+String code = e.getErrorCode(); // CustomException에서 제공
+if (StaffErrorCode.INVALID_DEPARTMENT.name().equals(code)) { ... }
+```
+
+- [ ] **Step 4: 컴파일 + AdminStaffControllerTest 실행**
+
+```bash
+./mvnw test -pl . -Dtest="AdminStaffControllerTest,AdminStaffServiceTest" -q 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/admin/staff/
+git commit -m "fix: N-M-04 AdminStaffController 에러 라우팅 → StaffErrorCode enum 기반으로 교체"
+```
+
+---
+
+## Group 4: 아키텍처 — 다중 Repository 통합 (H-01)
+
+**대상:** `Reservation` 4개, `Patient` 3개, `Staff` 2개, `Department` 2개 Repository 중복.
+**방침:** 각 엔티티의 정식(canonical) Repository 1개를 선정하고, 나머지 중복 Repository의 메서드를 정식 Repository로 병합. 중복 Repository를 삭제하고 이를 사용하던 Service/Controller의 import를 정식 Repository로 교체.
+
+---
+
+### Task 17: H-01 — Reservation 중복 Repository 통합
+
+**정식 Repository:** `reservation/reservation/ReservationRepository.java`
+**중복:** `admin/reservation/AdminReservationRepository.java` (Reservation 관련 메서드), `nurse/NursePatientStatusRepository.java` (Reservation 쿼리), `staff/` 내 Reservation 쿼리
+
+- [ ] **Step 1: 정식 Repository 현황 파악**
+
+```bash
+grep -r "extends JpaRepository" src/main/java/com/smartclinic/hms/ | grep -i reservation
+grep -r "extends JpaRepository" src/main/java/com/smartclinic/hms/ | grep -i patient
+grep -r "extends JpaRepository" src/main/java/com/smartclinic/hms/ | grep -i staff
+grep -r "extends JpaRepository" src/main/java/com/smartclinic/hms/ | grep -i department
+```
+
+- [ ] **Step 2: 정식 Repository에 누락 메서드 병합**
+
+각 중복 Repository에서 정식 Repository에 없는 쿼리 메서드를 식별하고 복사.
+메서드명 충돌 시 더 명확한 이름으로 통일.
+
+- [ ] **Step 3: 중복 Repository를 참조하는 Service/Controller 업데이트**
+
+```bash
+# 사용 위치 확인
+grep -r "AdminReservationRepository\|NursePatientRepository\|AdminPatientRepository" \
+    src/main/java/ --include="*.java" -l
+```
+각 파일에서 중복 Repository import를 정식 Repository import로 교체.
+생성자 주입 필드도 교체.
+
+- [ ] **Step 4: 중복 Repository 파일 삭제**
+
+삭제 전 해당 파일이 더 이상 참조되지 않음을 `grep`으로 확인.
+
+- [ ] **Step 5: 컴파일 + 전체 테스트**
+
+```bash
+./mvnw test -pl . -q 2>&1 | tail -20
+```
+Expected: BUILD SUCCESS, 0 failures
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "fix: H-01 동일 엔티티 다중 Repository 통합 — 정식 Repository 단일화"
+```
+
+---
+
+## Group 5: 기타 — Clock, TestSecurityConfig, LLM 테스트, 인터셉터, L-01~L-03
+
+---
+
+### Task 18: M-03 + N-M-02 — LocalDate.now() → Clock 주입
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/nurse/NurseService.java:37`
+- Modify: `src/main/java/com/smartclinic/hms/staff/reception/ReceptionService.java:178,303`
+- Modify: `src/main/java/com/smartclinic/hms/doctor/treatment/DoctorTreatmentService.java:34,106,118,167,183,228`
+
+**패턴:**
+```java
+// 변경 전
+LocalDate today = LocalDate.now();
+
+// 변경 후 (Clock 주입 후)
+LocalDate today = LocalDate.now(clock);
+```
+
+```java
+// Service 클래스
+@Service
+public class SomeService {
+    private final Clock clock;
+
+    public SomeService(/* 기존 의존성 */, Clock clock) { ... }
+}
+```
+
+`Clock` 빈은 `@Configuration` 클래스에 등록:
+```java
+@Bean
+public Clock clock() {
+    return Clock.systemDefaultZone();
+}
+```
+
+- [ ] **Step 1: ClockConfig 빈 등록 확인 (없으면 생성)**
+
+```bash
+grep -r "Clock" src/main/java/com/smartclinic/hms/config/ --include="*.java"
+```
+없으면 기존 Config 클래스에 `@Bean public Clock clock() { return Clock.systemDefaultZone(); }` 추가.
+
+- [ ] **Step 2: NurseService — Clock 주입 + LocalDate.now() 교체**
+
+생성자에 `Clock clock` 추가. `LocalDate.now()` → `LocalDate.now(clock)`.
+
+- [ ] **Step 3: ReceptionService — Clock 주입 + LocalDate.now() 교체**
+
+lines 178, 303의 `LocalDate.now()` → `LocalDate.now(clock)`.
+
+- [ ] **Step 4: DoctorTreatmentService — Clock 주입 + LocalDate.now() 교체**
+
+lines 34, 106, 118, 167, 183, 228의 `LocalDate.now()` / `LocalDateTime.now()` → `Clock` 기반으로 교체.
+
+- [ ] **Step 5: 컴파일 + 테스트**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "fix: M-03/N-M-02 LocalDate.now() → Clock 주입으로 테스트 가능성 개선"
+```
+
+---
+
+### Task 19: M-04 — TestSecurityConfig 중복 제거
+
+**Files:**
+- Create: `src/test/java/com/smartclinic/hms/common/SharedTestSecurityConfig.java`
+- Modify: 기존 10+ WebMvcTest 클래스에서 내부 중복 `TestSecurityConfig` 제거
+
+- [ ] **Step 1: 기존 공통 설정 파일 확인**
+
+`AdminControllerTestSecurityConfig.java`와 `LlmWebMvcTestSecurityConfig.java`가 이미 공통 클래스로 존재.
+각 WebMvcTest 클래스가 어떤 내부 클래스를 갖고 있는지 확인:
+
+```bash
+grep -r "TestConfiguration" src/test/ --include="*.java" -l
+```
+
+- [ ] **Step 2: SharedTestSecurityConfig 생성 (role 통합)**
+
+```java
+package com.smartclinic.hms.common;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+public class SharedTestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable())
+                .build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new InMemoryUserDetailsManager(
+                User.withUsername("admin").password("{noop}password").roles("ADMIN").build(),
+                User.withUsername("doctor").password("{noop}password").roles("DOCTOR").build(),
+                User.withUsername("nurse").password("{noop}password").roles("NURSE").build(),
+                User.withUsername("staff").password("{noop}password").roles("STAFF").build());
+    }
+}
+```
+
+- [ ] **Step 3: 각 WebMvcTest 클래스에서 내부 중복 TestSecurityConfig 제거**
+
+각 테스트 클래스의 `@Import` 어노테이션을 `SharedTestSecurityConfig.class`로 교체하거나 추가.
+내부 `@TestConfiguration` 클래스 삭제.
+
+- [ ] **Step 4: 전체 테스트 실행**
+
+```bash
+./mvnw test -pl . -q 2>&1 | tail -20
+```
+Expected: BUILD SUCCESS, 0 failures
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/test/
+git commit -m "fix: M-04 TestSecurityConfig 중복 → SharedTestSecurityConfig 공통화"
+```
+
+---
+
+### Task 20: M-05 — LLM 서비스 테스트 보강
+
+**Files:**
+- Modify: `src/test/java/com/smartclinic/hms/llm/LlmReservationServiceTest.java`
+- Modify: `src/test/java/com/smartclinic/hms/llm/SymptomAnalysisServiceTest.java`
+
+- [ ] **Step 1: 기존 테스트 파일 현황 파악**
+
+```bash
+cat src/test/java/com/smartclinic/hms/llm/LlmReservationServiceTest.java | head -50
+cat src/test/java/com/smartclinic/hms/llm/SymptomAnalysisServiceTest.java | head -50
+```
+
+- [ ] **Step 2: LlmReservationServiceTest 핵심 케이스 추가**
+
+BDDMockito + Given-When-Then + @DisplayName 패턴으로:
+- 정상 예약 생성 흐름
+- 슬롯 중복 시 예외 발생
+- LLM 응답 파싱 실패 시 예외 발생
+
+- [ ] **Step 3: SymptomAnalysisServiceTest 핵심 케이스 추가**
+
+- 증상 분석 정상 흐름
+- LLM 타임아웃 시 `LlmTimeoutException` 발생
+- 서비스 불가 시 `LlmServiceUnavailableException` 발생
+
+- [ ] **Step 4: 테스트 실행**
+
+```bash
+./mvnw test -pl . -Dtest="LlmReservationServiceTest,SymptomAnalysisServiceTest" -q 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/test/java/com/smartclinic/hms/llm/
+git commit -m "fix: M-05 LlmReservationService/SymptomAnalysisService 단위 테스트 보강"
+```
+
+---
+
+### Task 21: N-M-03 — InactiveStaffLogoutInterceptor 세션 캐시
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/common/interceptor/InactiveStaffLogoutInterceptor.java`
+
+**방침:** 최초 인증된 요청에서 `staff.isActive()`를 확인하고 결과를 `HttpSession` 어트리뷰트에 저장. 이후 요청에서는 세션에서 먼저 확인하고 DB 조회 생략.
+
+```java
+private static final String SESSION_KEY = "staffActive";
+
+@Override
+public boolean preHandle(...) {
+    // 인증 없으면 통과
+    ...
+    HttpSession session = request.getSession(false);
+    if (session != null) {
+        Boolean cached = (Boolean) session.getAttribute(SESSION_KEY);
+        if (cached != null) {
+            if (!cached) {
+                // 이미 비활성화 확인됨 → 로그아웃
+                logoutHandler.logout(request, response, authentication);
+                redirectToDeactivatedLogin(request, response);
+                return false;
+            }
+            return true; // 활성화 확인됨 → DB 조회 생략
+        }
+    }
+    // DB 조회 후 세션에 캐시
+    return staffRepository.findByUsername(authentication.getName())
+            .map(staff -> {
+                boolean active = staff.isActive();
+                if (session != null) session.setAttribute(SESSION_KEY, active);
+                return handleStaff(request, response, authentication, staff);
+            })
+            .orElse(true);
+}
+```
+
+- [ ] **Step 1: InactiveStaffLogoutInterceptor 세션 캐시 구현**
+
+위 패턴으로 `preHandle` 메서드 수정.
+
+- [ ] **Step 2: InactiveStaffLogoutInterceptorTest 실행**
+
+```bash
+./mvnw test -pl . -Dtest=InactiveStaffLogoutInterceptorTest -q 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/smartclinic/hms/common/interceptor/InactiveStaffLogoutInterceptor.java
+git commit -m "fix: N-M-03 InactiveStaffLogoutInterceptor 매 요청 DB 조회 → 세션 캐시로 개선"
+```
+
+---
+
+### Task 22: L-01 + L-02 + L-03 — 저우선순위 개선
+
+**Files:**
+- Modify: `src/main/java/com/smartclinic/hms/domain/Doctor.java` (availableDays 정규화)
+- Modify: `src/main/java/com/smartclinic/hms/common/interceptor/LayoutModelInterceptor.java` (boolean 플래그)
+- Modify: `src/main/java/com/smartclinic/hms/domain/StaffRole.java` (getDashboardUrl)
+- Modify: `src/main/java/com/smartclinic/hms/config/SecurityConfig.java` (switch 제거)
+
+- [ ] **Step 1: L-03 — StaffRole에 getDashboardUrl() 추가**
+
+```java
+public enum StaffRole {
+    ADMIN, DOCTOR, NURSE, STAFF, ITEM_MANAGER;
+
+    public String getDashboardUrl() {
+        return switch (this) {
+            case ADMIN -> "/admin/dashboard";
+            case DOCTOR -> "/doctor/dashboard";
+            case NURSE -> "/nurse/dashboard";
+            case STAFF -> "/staff/dashboard";
+            case ITEM_MANAGER -> "/item-manager/dashboard";
+        };
+    }
+}
+```
+
+`SecurityConfig`와 `LayoutModelInterceptor`의 중복 switch를 `role.getDashboardUrl()` 호출로 교체.
+
+- [ ] **Step 2: L-02 — LayoutModelInterceptor boolean 플래그 정리**
+
+26개 boolean 플래그(`isAdminDashboard` 등) 중 `path.contains()` 방식의 부정확한 매칭을 `path.startsWith()` 또는 정확한 패턴으로 교체.
+
+- [ ] **Step 3: L-01 — Doctor.availableDays 공백 정규화**
+
+`availableDays` setter 또는 저장 로직에서 공백 트리밍 처리:
+
+```java
+// Doctor 엔티티 setter 또는 AdminStaffService.save()에서
+if (availableDays != null) {
+    availableDays = Arrays.stream(availableDays.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .collect(Collectors.joining(","));
+}
+```
+
+- [ ] **Step 4: 컴파일 + 전체 테스트**
+
+```bash
+./mvnw compile -pl . -am -q 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "fix: L-01/L-02/L-03 availableDays 정규화, LayoutModelInterceptor 플래그 정리, StaffRole.getDashboardUrl()"
+```
+
+---
+
+## Final: 전체 테스트 실행 및 검증
+
+### Task 23: 전체 테스트 + 빌드 최종 확인
+
+- [ ] **Step 1: 전체 테스트 실행**
+
+```bash
+cd c:/workspace/gitstudy_lab/demo/team-demo/team-project-demo/hms
+./mvnw test -pl . 2>&1 | tail -30
+```
+Expected: `BUILD SUCCESS`, `Tests run: N, Failures: 0, Errors: 0`
+
+- [ ] **Step 2: 실패 테스트가 있으면 진단**
+
+```bash
+./mvnw test -pl . 2>&1 | grep -E "FAIL|ERROR|Exception" | head -30
+```
+
+- [ ] **Step 3: 코드 리뷰 이슈 체크리스트 확인**
+
+각 이슈 ID별 수정 완료 여부를 `doc/CODE_REVIEW_2026-03-25.md` 기준으로 검토.
+
+- [ ] **Step 4: 최종 Commit (미커밋 잔여분 처리)**
+
+```bash
+git status
+git add -A
+git commit -m "fix: HMS 코드 리뷰 29건 수정 완료 — CRITICAL 3 / HIGH 12 / MEDIUM 9 / LOW 5"
+```
+
+---
+
+## 이슈 ID → Task 매핑 요약
+
+| 이슈 ID | 심각도 | Task | 설명 |
+|---------|--------|------|------|
+| C-01 | CRITICAL | Task 1 | tools.jackson import |
+| C-03 | CRITICAL | Task 2 | AdminStaffService 깨진 문자열 |
+| C-02 / N-M-01 | CRITICAL / MEDIUM | Task 3 | innerHTML XSS |
+| M-06 | MEDIUM | Task 4 | var → const/let |
+| M-07 | MEDIUM | Task 5 | _sample @Profile |
+| M-08 | MEDIUM | Task 6 | toKoreanDayOfWeek 제거 |
+| H-08 | HIGH | Task 7 | 중복 CSS 삭제 |
+| L-04, L-05 | LOW | Task 8 | 죽은 JS / nativeQuery |
+| H-04 | HIGH | Task 9 | AdminItemApiController |
+| H-09 | HIGH | Task 10 | NurseItemApiController |
+| N-H-01 | HIGH | Task 11 | DoctorTreatmentApiController |
+| N-H-03 | HIGH | Task 12 | ReceptionApiController |
+| N-H-02, N-H-04 | HIGH | Task 13 | Model → HttpServletRequest |
+| N-H-05, H-05, H-06 | HIGH | Task 14 | ReceptionService 로직 위임 + N+1 |
+| H-07 | HIGH | Task 15 | NurseService N+1 |
+| N-M-04 | MEDIUM | Task 16 | 에러 코드 기반 라우팅 |
+| H-01 | HIGH | Task 17 | 다중 Repository 통합 |
+| M-03, N-M-02 | MEDIUM | Task 18 | Clock 주입 |
+| M-04 | MEDIUM | Task 19 | TestSecurityConfig 공통화 |
+| M-05 | MEDIUM | Task 20 | LLM 서비스 테스트 |
+| N-M-03 | MEDIUM | Task 21 | 인터셉터 세션 캐시 |
+| L-01, L-02, L-03 | LOW | Task 22 | 저우선순위 개선 |
+| - | - | Task 23 | 최종 테스트 확인 |

--- a/src/main/java/com/smartclinic/hms/reservation/reservation/ReservationCompleteInfo.java
+++ b/src/main/java/com/smartclinic/hms/reservation/reservation/ReservationCompleteInfo.java
@@ -1,7 +1,9 @@
 package com.smartclinic.hms.reservation.reservation;
 
-// 예약 완료 화면에 필요한 정보만 담는 DTO (flash attribute → Mustache {{#info}} 바인딩)
-// 트랜잭션 종료 후 LazyInitializationException 방지용
+import java.io.Serial;
+import java.io.Serializable;
+
+// DTO for reservation completion page flash attributes.
 public record ReservationCompleteInfo(
         String reservationNumber,
         String patientName,
@@ -9,5 +11,7 @@ public record ReservationCompleteInfo(
         String doctorName,
         String reservationDate,
         String timeSlot
-) {
+) implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/resources/application-prod.properties.example
+++ b/src/main/resources/application-prod.properties.example
@@ -82,11 +82,14 @@ server.error.include-message=never
 server.error.include-stacktrace=never
 
 # ------------------------------------------------------------------------------
-# Redis 캐시 (운영)
+# Redis 캐시 / 세션 (운영)
 # ------------------------------------------------------------------------------
 spring.data.redis.host=${SPRING_DATA_REDIS_HOST:192.168.0.22}
 spring.data.redis.port=${SPRING_DATA_REDIS_PORT:6379}
+spring.data.redis.repositories.enabled=false
 spring.cache.type=redis
+spring.session.store-type=redis
+spring.session.redis.namespace=hms:session
 
 # ------------------------------------------------------------------------------
 # CORS 허용 Origin (운영: LAN IP + localhost)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,7 @@ spring.web.error.whitelabel.enabled=false
 # 공통 JPA 설정
 # ------------------------------------------------------------------------------
 spring.jpa.open-in-view=false
+spring.data.redis.repositories.enabled=false
 
 # ------------------------------------------------------------------------------
 # 공통 Mustache 설정
@@ -53,3 +54,16 @@ spring.servlet.multipart.enabled=true
 # 로깅 — logback-spring.xml 에서 관리 (프로필별 콘솔/파일/에러 분리)
 # ------------------------------------------------------------------------------
 spring.output.ansi.enabled=ALWAYS
+
+# ------------------------------------------------------------------------------
+# 운영 프로필 전용 설정
+# ------------------------------------------------------------------------------
+# 개발 환경(dev, H2)은 기본 메모리 세션을 사용하고,
+# 운영 환경(prod)에서만 Redis 세션 저장소를 활성화한다.
+# ------------------------------------------------------------------------------
+#---
+spring.config.activate.on-profile=prod
+spring.cache.type=redis
+spring.session.store-type=redis
+spring.session.redis.namespace=hms:session
+server.servlet.session.timeout=30m

--- a/src/main/resources/templates/admin/staff-form.mustache
+++ b/src/main/resources/templates/admin/staff-form.mustache
@@ -291,8 +291,9 @@
             <div id="doctor-fields" class="border-t border-slate-200 pt-6 space-y-6 {{^model.doctorRole}}hidden{{/model.doctorRole}}">
               <div>
                 <h2 class="text-lg font-semibold text-slate-800">의사 전용 정보</h2>
-                <p class="text-sm text-slate-500 mt-1">의사 역할일 때만 진료과와 진료 가능 요일을 함께 관리합니다.</p>
+                <p class="text-sm text-slate-500 mt-1">의사 부서일 때만 진료과와 진료 가능 요일을 함께 관리합니다.</p>
               </div>
+
 
               <div>
                 <label for="doctor-department" class="block text-sm font-medium text-slate-700 mb-2">진료과</label>

--- a/src/main/resources/templates/admin/staff-list.mustache
+++ b/src/main/resources/templates/admin/staff-list.mustache
@@ -22,7 +22,7 @@
             </div>
             <div>
               <h1 class="text-2xl font-bold text-slate-800">{{pageTitle}}</h1>
-              <p class="text-slate-500 mt-1">이름, 로그인 아이디, 역할, 재직 상태 기준으로 직원을 조회합니다.</p>
+              <p class="text-slate-500 mt-1">이름, 로그인 아이디, 부서, 재직 상태 기준으로 직원을 조회합니다.</p>
             </div>
           </div>
           <div class="flex items-center gap-4">
@@ -68,7 +68,7 @@
               </div>
 
               <div class="min-w-[180px]">
-                <label for="staff-role" class="block text-sm font-medium text-slate-700 mb-1.5">역할</label>
+                <label for="staff-role" class="block text-sm font-medium text-slate-700 mb-1.5">부서</label>
                 <select
                   id="staff-role"
                   name="role"
@@ -108,8 +108,8 @@
                 <th class="p-4 font-medium">이름</th>
                 <th class="p-4 font-medium">로그인 아이디</th>
                 <th class="p-4 font-medium">사번</th>
-                <th class="p-4 font-medium">역할</th>
                 <th class="p-4 font-medium">부서</th>
+                <th class="p-4 font-medium">진료과</th>
                 <th class="p-4 font-medium">재직 상태</th>
                 <th class="p-4 font-medium text-right">관리</th>
               </tr>


### PR DESCRIPTION
## 작업 내용

- `spring-session-data-redis` 의존성을 추가했습니다.
- 운영 프로필에서 Redis를 세션 저장소로 사용하도록 설정했습니다.
- Redis repository 자동 스캔을 비활성화했습니다.
- flash attribute로 사용하는 `ReservationCompleteInfo`에 `Serializable`을 적용해 세션 직렬화 호환성을 보완했습니다.
- 운영 예시 설정 파일에 Redis 세션 관련 설정을 반영했습니다.

## 변경 파일

- `build.gradle`
- `src/main/resources/application.properties`
- `src/main/resources/application-prod.properties.example`
- `src/main/java/com/smartclinic/hms/reservation/reservation/ReservationCompleteInfo.java`

## 기대 효과

- 운영 환경에서 Spring Session 기반 Redis 세션 저장소를 사용할 수 있습니다.
- 세션/flash attribute 직렬화 이슈 가능성을 줄였습니다.
- 개발 환경(dev)과 운영 환경(prod)의 세션 전략이 분리됩니다.

## 테스트

- `./gradlew clean test`
- 결과: 성공

## 참고

- 개발 환경은 기존처럼 기본 메모리 세션을 사용합니다.
- 운영 환경에서만 Redis 세션 저장소가 활성화됩니다.
